### PR TITLE
Fix Dockerfile to work with Ubuntu 24.04 and Kubernetes args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -u 65534 -r nonroot
+RUN useradd -u 65534 -o -r nonroot
 
 WORKDIR /
 
@@ -24,4 +24,4 @@ EXPOSE 9998 9999
 
 USER nonroot
 
-CMD ["./resource-state-metrics"]
+ENTRYPOINT ["./resource-state-metrics"]


### PR DESCRIPTION
## What does this PR do?

<!-- A concise description of the change. -->

- Add -o flag to useradd because Ubuntu 24.04 already assigns UID 65534 to nobody, so creating a second user with that UID fails without allowing non-unique UIDs.
- Change CMD to ENTRYPOINT so that Kubernetes args in the deployment manifest append to the binary instead of replacing it entirely. With CMD, the container tried to execute --main-host=0.0.0.0 as a binary.

## Why is this change needed?

<!-- Motivation, linked issue, or context. -->

Fixes #

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (if applicable)
- [x] `make verify_codegen` passes (if generated code was changed)
- [x] `make lint` passes
