### PR TITLE
feat: add timestamp() function for duration-based metrics

### DIFF
--- a/pkg/resolver/cel.go
+++ b/pkg/resolver/cel.go
@@ -295,7 +295,7 @@ func labelPrefixBinding(lhs, rhs ref.Val) ref.Val {
 // returns the current time as Unix seconds (a double). This enables computing
 // durations by subtracting a resource's lastTransitionTime from the current
 // time, e.g., `timestamp() - unixSeconds(o.status.conditions[0].lastTransitionTime)`.
-func timestampBinding(args ...ref.Val) ref.Val {
+func timestampBinding(_ ...ref.Val) ref.Val {
 	return types.Double(float64(time.Now().Unix()))
 }
 

--- a/pkg/resolver/cel.go
+++ b/pkg/resolver/cel.go
@@ -76,6 +76,7 @@ const (
 	celCostUnixSeconds uint64 = 10
 	celCostQuantity    uint64 = 10
 	celCostLabelPrefix uint64 = 20
+	celCostTimestamp   uint64 = 1
 )
 
 // CallCost sets the runtime cost for CEL queries on a per-function basis.
@@ -84,6 +85,7 @@ func (ce costEstimator) CallCost(function string, _ string, _ []ref.Val, _ ref.V
 		"unixSeconds": celCostUnixSeconds,
 		"quantity":    celCostQuantity,
 		"labelPrefix": celCostLabelPrefix,
+		"timestamp":   celCostTimestamp,
 	}
 	estimatedCost := 1 + customFunctionsCosts[function]
 
@@ -195,6 +197,13 @@ func (cr *CELResolver) createEnvironment() (*cel.Env, error) {
 				cel.BinaryBinding(labelPrefixBinding),
 			),
 		),
+		cel.Function("timestamp",
+			cel.Overload("timestamp_void",
+				[]*cel.Type{},
+				cel.DoubleType,
+				cel.FunctionBinding(timestampBinding),
+			),
+		),
 	)
 }
 
@@ -280,6 +289,14 @@ func labelPrefixBinding(lhs, rhs ref.Val) ref.Val {
 	}
 
 	return types.NewStringStringMap(types.DefaultTypeAdapter, result)
+}
+
+// timestampBinding implements the logic for the timestamp function, which
+// returns the current time as Unix seconds (a double). This enables computing
+// durations by subtracting a resource's lastTransitionTime from the current
+// time, e.g., `timestamp() - unixSeconds(o.status.conditions[0].lastTransitionTime)`.
+func timestampBinding(args ...ref.Val) ref.Val {
+	return types.Double(float64(time.Now().Unix()))
 }
 
 func (cr *CELResolver) compileProgram(env *cel.Env, ast *cel.Ast) (cel.Program, error) {

--- a/pkg/resolver/cel_test.go
+++ b/pkg/resolver/cel_test.go
@@ -270,12 +270,12 @@ func TestCELResolver_Quantity(t *testing.T) {
 func TestCELResolver_Timestamp(t *testing.T) {
 	t.Parallel()
 
-	cr := NewCELResolver(klog.NewKlogr(), 10e5, 5*time.Second, nil, "test-ns", "test-rmm", "test-family")
+	resolver := NewCELResolver(klog.NewKlogr(), 10e5, 5*time.Second, nil, "test-ns", "test-rmm", "test-family")
 
 	t.Run("returns current unix seconds", func(t *testing.T) {
 		t.Parallel()
 
-		got := cr.Resolve(`timestamp()`, map[string]any{})
+		got := resolver.Resolve(`timestamp()`, map[string]any{})
 		if len(got) != 1 {
 			t.Fatalf("expected 1 result, got %d", len(got))
 		}
@@ -296,7 +296,7 @@ func TestCELResolver_Timestamp(t *testing.T) {
 	t.Run("compute duration since transition", func(t *testing.T) {
 		t.Parallel()
 
-		got := cr.Resolve(`timestamp() - unixSeconds(o.timestamp)`, map[string]any{"timestamp": "2024-01-15T10:30:00Z"})
+		got := resolver.Resolve(`timestamp() - unixSeconds(o.timestamp)`, map[string]any{"timestamp": "2024-01-15T10:30:00Z"})
 		if len(got) != 1 {
 			t.Fatalf("expected 1 result, got %d", len(got))
 		}

--- a/pkg/resolver/cel_test.go
+++ b/pkg/resolver/cel_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package resolver
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -264,6 +265,54 @@ func TestCELResolver_Quantity(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCELResolver_Timestamp(t *testing.T) {
+	t.Parallel()
+
+	cr := NewCELResolver(klog.NewKlogr(), 10e5, 5*time.Second, nil, "test-ns", "test-rmm", "test-family")
+
+	t.Run("returns current unix seconds", func(t *testing.T) {
+		t.Parallel()
+
+		got := cr.Resolve(`timestamp()`, map[string]any{})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(got))
+		}
+
+		for _, v := range got {
+			f, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				t.Fatalf("expected numeric result, got %q: %v", v, err)
+			}
+
+			// Should be a reasonable Unix epoch (after 2024-01-01)
+			if f < 1704067200 {
+				t.Errorf("timestamp %f is too small (before 2024-01-01)", f)
+			}
+		}
+	})
+
+	t.Run("compute duration since transition", func(t *testing.T) {
+		t.Parallel()
+
+		got := cr.Resolve(`timestamp() - unixSeconds(o.timestamp)`, map[string]any{"timestamp": "2024-01-15T10:30:00Z"})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(got))
+		}
+
+		for _, v := range got {
+			f, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				t.Fatalf("expected numeric result, got %q: %v", v, err)
+			}
+
+			// Duration since 2024-01-15 should be positive
+			if f <= 0 {
+				t.Errorf("expected positive duration, got %f", f)
+			}
+		}
+	})
 }
 
 func TestCELResolver_LabelPrefix(t *testing.T) {

--- a/pkg/resolver/starlark.go
+++ b/pkg/resolver/starlark.go
@@ -127,6 +127,7 @@ func (sr *StarlarkResolver) resolveWithSteps(thread *starlark.Thread, obj map[st
 		"metric":            starlark.NewBuiltin("metric", metricBuiltin),
 		"family":            starlark.NewBuiltin("family", familyBuiltin),
 		"label_prefix":      starlark.NewBuiltin("label_prefix", labelPrefixBuiltin),
+		"timestamp":         starlark.NewBuiltin("timestamp", timestampBuiltin),
 	}
 
 	objValue, err := goToStarlark(obj)
@@ -253,6 +254,17 @@ func labelPrefixBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	}
 
 	return result, nil
+}
+
+// timestampBuiltin returns the current time as Unix seconds (a float).
+// This enables computing durations, e.g., `timestamp() - unix_seconds` where
+// unix_seconds was parsed from a resource's lastTransitionTime.
+func timestampBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if err := starlark.UnpackArgs("timestamp", args, kwargs); err != nil {
+		return nil, err
+	}
+
+	return starlark.Float(float64(time.Now().Unix())), nil
 }
 
 // goToStarlark converts a Go value to a Starlark value.

--- a/pkg/resolver/starlark_test.go
+++ b/pkg/resolver/starlark_test.go
@@ -562,6 +562,93 @@ families = [family(name="test", help="test", kind="gauge", samples=[
 	}
 }
 
+func TestStarlarkResolver_Timestamp(t *testing.T) {
+	t.Parallel()
+
+	script := `
+now = timestamp()
+samples = [
+    metric(labels={"type": "current"}, value=now),
+]
+families = [
+    family(name="timestamp_metric", help="Current timestamp", kind="gauge", samples=samples)
+]
+`
+
+	obj := map[string]interface{}{}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	families, err := sg.Resolve(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(families) != 1 || len(families[0].Samples) != 1 {
+		t.Fatalf("expected 1 family with 1 sample")
+	}
+
+	ts := families[0].Samples[0].Value
+	// The timestamp should be a reasonable Unix epoch (after 2024-01-01)
+	if ts < 1704067200 {
+		t.Errorf("timestamp %f is too small (before 2024-01-01)", ts)
+	}
+}
+
+func TestStarlarkResolver_TimestampDuration(t *testing.T) {
+	t.Parallel()
+
+	// Compute duration: timestamp() - a known past time (2024-01-15T10:30:00Z = 1705314600)
+	script := `
+past_unix = 1705314600.0
+duration = timestamp() - past_unix
+samples = [
+    metric(labels={"kind": "test"}, value=duration),
+]
+families = [
+    family(name="duration_metric", help="Duration since event", kind="gauge", samples=samples)
+]
+`
+
+	obj := map[string]interface{}{}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	families, err := sg.Resolve(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(families) != 1 || len(families[0].Samples) != 1 {
+		t.Fatalf("expected 1 family with 1 sample")
+	}
+
+	duration := families[0].Samples[0].Value
+	// Duration since 2024-01-15 should be positive and large
+	if duration < 0 {
+		t.Errorf("expected positive duration, got %f", duration)
+	}
+}
+
+func TestStarlarkResolver_TimestampNoArgs(t *testing.T) {
+	t.Parallel()
+
+	// timestamp() should fail if called with arguments
+	script := `
+ts = timestamp("bad_arg")
+families = []
+`
+
+	obj := map[string]interface{}{}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	_, err := sg.Resolve(obj)
+	if err == nil {
+		t.Fatal("expected error when calling timestamp with arguments, got nil")
+	}
+}
+
 func TestStarlarkResolver_FileOptions_Set(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds a zero-argument `timestamp()` function to both the CEL and Starlark resolvers that returns the current time as Unix seconds (float64).

This enables computing **duration-based metrics** directly in metric expressions — for example, "seconds since a resource's last condition transition" — without requiring PromQL's `time()` function.

### Motivation

Monitoring systems like Datadog ingest Prometheus-format metrics but don't support PromQL's `time()` at query time. Today, RSM can emit `lastTransitionTime` as a Unix timestamp via `unixSeconds()`, but computing "how long has this resource been unhealthy?" requires `time() - last_transition_timestamp` in PromQL. With `timestamp()`, the duration can be computed at scrape time:

```yaml
# CEL: seconds since the Ready condition last transitioned
value: |
  o.status.conditions.exists(c, c.type == 'Ready') ?
    timestamp() - unixSeconds(o.status.conditions.filter(c, c.type == 'Ready')[0].lastTransitionTime) : 0
```

```python
# Starlark: same computation
for c in obj.get("status", {}).get("conditions", []):
    if c["type"] == "Ready":
        duration = timestamp() - quantity_to_float(c.get("lastTransitionTime", "0"))
```

This enables alerts like "any resource unsynced for > 30 minutes" using a simple threshold (`max by {kind} > 1800`) instead of requiring per-resource timeseries with PromQL arithmetic.

### Changes

- **CEL resolver**: Register `timestamp()` as a zero-arg function returning `DoubleType` with CEL cost budget of 1 (reads system clock only)
- **Starlark resolver**: Register `timestamp()` as a zero-arg builtin returning `Float`
- **Tests**: 5 new tests covering basic usage, duration computation, and argument validation for both resolvers

### Design decisions

- **Cost = 1**: `timestamp()` just calls `time.Now().Unix()` — cheaper than `unixSeconds` (which parses RFC3339) or `quantity` (which parses Kubernetes quantities)
- **Returns float64 (Unix seconds)**: Consistent with `unixSeconds()` return type, enabling direct arithmetic like `timestamp() - unixSeconds(...)`
- **Zero-arg with validation**: Starlark builtin uses `UnpackArgs` to reject unexpected arguments; CEL uses `FunctionBinding` with empty arg types