### PR TITLE
Ensure label and metric values correspond by position

### DIFF
--- a/internal/family.go
+++ b/internal/family.go
@@ -283,27 +283,7 @@ func resolveMetricValue(resolverInstance resolver.Resolver, valueExpr string, ob
 		return resolvedValue, true
 	}
 
-	var expandedValues []string
-
-	for i := 0; ; i++ {
-		suffix := "#" + strconv.Itoa(i)
-
-		var match string
-
-		for k, v := range resolvedValueMap {
-			if strings.HasSuffix(k, suffix) {
-				match = v
-
-				break
-			}
-		}
-
-		if match == "" {
-			break
-		}
-
-		expandedValues = append(expandedValues, match)
-	}
+	expandedValues := collectIndexedResolvedValues(resolvedValueMap)
 
 	if len(expandedValues) == 0 {
 		return "", false
@@ -345,26 +325,7 @@ func resolveLabels(labels []v1alpha1.Label, resolverInstance resolver.Resolver, 
 		// to match the order used by resolveMetricValue. Map iteration order is
 		// non-deterministic and would decouple labels from their metric values.
 		sanitizedName := sanitizeKey(label.Name)
-
-		for i := 0; ; i++ {
-			suffix := "#" + strconv.Itoa(i)
-
-			var match string
-
-			for k, v := range resolvedLabelset {
-				if strings.HasSuffix(k, suffix) {
-					match = v
-
-					break
-				}
-			}
-
-			if match == "" {
-				break
-			}
-
-			resolvedExpandedLabelSet[sanitizedName] = append(resolvedExpandedLabelSet[sanitizedName], match)
-		}
+		resolvedExpandedLabelSet[sanitizedName] = append(resolvedExpandedLabelSet[sanitizedName], collectIndexedResolvedValues(resolvedLabelset)...)
 
 		// Process non-list entries (map keys, non-composite values).
 		for k, v := range resolvedLabelset {
@@ -421,6 +382,37 @@ func sortLabels(keys []string, parallel ...[]string) {
 			reorder(p)
 		}
 	}
+}
+
+// collectIndexedResolvedValues returns resolver values stored under numbered
+// keys with #0, #1, ... suffixes, preserving empty string values.
+func collectIndexedResolvedValues(resolved map[string]string) []string {
+	var values []string
+
+	for i := 0; ; i++ {
+		suffix := "#" + strconv.Itoa(i)
+
+		var match string
+
+		found := false
+
+		for k, v := range resolved {
+			if strings.HasSuffix(k, suffix) {
+				match = v
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			break
+		}
+
+		values = append(values, match)
+	}
+
+	return values
 }
 
 // sanitizeKey converts a label key to snake_case and strips non-alphanumeric characters.

--- a/internal/family.go
+++ b/internal/family.go
@@ -184,7 +184,7 @@ func (f *FamilyType) buildMetricString(unstructured *unstructured.Unstructured) 
 
 		resolvedLabelKeys, resolvedLabelValues, resolvedExpandedLabelSet := resolveLabels(metricLabels, resolverInstance, unstructured.Object)
 
-		resolvedValue, ok := resolveMetricValue(resolverInstance, metric.Value, unstructured.Object, &resolvedExpandedLabelSet)
+		resolvedValue, ok := resolveMetricValue(resolverInstance, metric.Value, unstructured.Object, resolvedExpandedLabelSet)
 		if !ok {
 			logger.V(1).Error(fmt.Errorf("error resolving metric value %q", metric.Value), "skipping")
 			putBuilder(metricRawBuilder)
@@ -277,7 +277,7 @@ func inheritMetricLabels(f *FamilyType, metric *v1alpha1.Metric) []v1alpha1.Labe
 // a list (indexed keys like "fieldParent#N"), the values are collected in
 // order and stored in resolvedExpandedLabelSet under the sentinel key so that
 // writeMetricSamples can emit one sample per element.
-func resolveMetricValue(resolverInstance resolver.Resolver, valueExpr string, obj map[string]any, resolvedExpandedLabelSet *map[string][]string) (string, bool) {
+func resolveMetricValue(resolverInstance resolver.Resolver, valueExpr string, obj map[string]any, resolvedExpandedLabelSet map[string][]string) (string, bool) {
 	resolvedValueMap := resolverInstance.Resolve(valueExpr, obj)
 	if resolvedValue, found := resolvedValueMap[valueExpr]; found {
 		return resolvedValue, true
@@ -289,7 +289,7 @@ func resolveMetricValue(resolverInstance resolver.Resolver, valueExpr string, ob
 		return "", false
 	}
 
-	(*resolvedExpandedLabelSet)[expandedValueSentinel] = expandedValues
+	resolvedExpandedLabelSet[expandedValueSentinel] = expandedValues
 
 	return "", true
 }

--- a/internal/family.go
+++ b/internal/family.go
@@ -332,50 +332,52 @@ func resolveLabels(labels []v1alpha1.Label, resolverInstance resolver.Resolver, 
 		if val, ok := resolvedLabelset[label.Value]; ok {
 			resolvedLabelValues = append(resolvedLabelValues, val)
 			resolvedLabelKeys = append(resolvedLabelKeys, sanitizeKey(label.Name))
-		} else {
-			// Check if this is a map expansion label (name starts with "_").
-			// In this case, map keys become label names directly without concatenation.
-			isMapExpansion := strings.HasPrefix(label.Name, "_")
 
-			// Collect list-indexed values in deterministic suffix order (#0, #1, ...)
-			// to match the order used by resolveMetricValue. Map iteration order is
-			// non-deterministic and would decouple labels from their metric values.
-			sanitizedName := sanitizeKey(label.Name)
+			continue
+		}
 
-			for i := 0; ; i++ {
-				suffix := "#" + strconv.Itoa(i)
+		// Check if this is a map expansion label (name starts with "_").
+		// In this case, map keys become label names directly without concatenation.
+		isMapExpansion := strings.HasPrefix(label.Name, "_")
 
-				var match string
+		// Collect list-indexed values in deterministic suffix order (#0, #1, ...)
+		// to match the order used by resolveMetricValue. Map iteration order is
+		// non-deterministic and would decouple labels from their metric values.
+		sanitizedName := sanitizeKey(label.Name)
 
-				for k, v := range resolvedLabelset {
-					if strings.HasSuffix(k, suffix) {
-						match = v
+		for i := 0; ; i++ {
+			suffix := "#" + strconv.Itoa(i)
 
-						break
-					}
-				}
+			var match string
 
-				if match == "" {
+			for k, v := range resolvedLabelset {
+				if strings.HasSuffix(k, suffix) {
+					match = v
+
 					break
 				}
-
-				resolvedExpandedLabelSet[sanitizedName] = append(resolvedExpandedLabelSet[sanitizedName], match)
 			}
 
-			// Process non-list entries (map keys, non-composite values).
-			for k, v := range resolvedLabelset {
-				if listIndexRegex.MatchString(k) {
-					continue
-				}
+			if match == "" {
+				break
+			}
 
-				resolvedLabelValues = append(resolvedLabelValues, v)
+			resolvedExpandedLabelSet[sanitizedName] = append(resolvedExpandedLabelSet[sanitizedName], match)
+		}
 
-				if isMapExpansion {
-					// Map expansion: use the map key directly as the label name
-					resolvedLabelKeys = append(resolvedLabelKeys, sanitizeKey(k))
-				} else {
-					resolvedLabelKeys = append(resolvedLabelKeys, sanitizeKey(label.Name+k))
-				}
+		// Process non-list entries (map keys, non-composite values).
+		for k, v := range resolvedLabelset {
+			if listIndexRegex.MatchString(k) {
+				continue
+			}
+
+			resolvedLabelValues = append(resolvedLabelValues, v)
+
+			if isMapExpansion {
+				// Map expansion: use the map key directly as the label name
+				resolvedLabelKeys = append(resolvedLabelKeys, sanitizeKey(k))
+			} else {
+				resolvedLabelKeys = append(resolvedLabelKeys, sanitizeKey(label.Name+k))
 			}
 		}
 	}
@@ -419,17 +421,11 @@ func sanitizeKey(s string) string {
 	return strcase.ToSnake(nonWordRegex.ReplaceAllString(s, "_"))
 }
 
-// writeMetricSamplesWithCount writes single or expanded metric values and returns the sample count.
-func writeMetricSamplesWithCount(
-	builder *strings.Builder,
-	name string,
-	kind MetricKind,
-	raw *unstructured.Unstructured,
-	keys, values []string,
-	expanded map[string][]string,
-	value string,
-	logger klog.Logger,
-) (int64, error) {
+// extractAndSortExpandedValues extracts expanded values from the sentinel key and co-sorts them with labels to maintain index correspondence.
+// The sentinel key is removed from the expanded map after extraction.
+// If there is a length mismatch between the expanded values and labels, a warning is logged and values are not co-sorted to avoid misalignment.
+// If multiple label keys are present, they are co-sorted together based on the anchor key (the lexicographically smallest label key) to maintain their relative order.
+func extractAndSortExpandedValues(expanded map[string][]string, logger klog.Logger) []string {
 	// Extract per-sample values stored under the sentinel when the value
 	// expression resolved to a list. The sentinel is not a real label.
 	// NOTE that we do not want resolver-specific logic making its way into
@@ -442,42 +438,62 @@ func writeMetricSamplesWithCount(
 	// Co-sort all expanded arrays (labels + values) to maintain index
 	// correspondence. Without this, sorting label values independently
 	// decouples them from their metric values.
-	if len(expanded) > 0 {
-		var sortKey string
-		for k := range expanded {
-			if sortKey == "" || k < sortKey {
-				sortKey = k
-			}
-		}
-
-		anchor := expanded[sortKey]
-		parallel := make([][]string, 0, len(expanded)+1)
-
-		for k := range expanded {
-			if k != sortKey {
-				parallel = append(parallel, expanded[k])
-			}
-		}
-
-		if len(expandedValues) == len(anchor) {
-			parallel = append(parallel, expandedValues)
-		}
-
-		sortLabels(anchor, parallel...)
+	if len(expanded) == 0 {
+		return expandedValues
 	}
+
+	var sortKey string
+	for k := range expanded {
+		if sortKey == "" || k < sortKey {
+			sortKey = k
+		}
+	}
+
+	anchor := expanded[sortKey]
+	parallel := make([][]string, 0, len(expanded)+1)
+
+	for k := range expanded {
+		if k != sortKey {
+			parallel = append(parallel, expanded[k])
+		}
+	}
+
+	if len(expandedValues) == len(anchor) {
+		parallel = append(parallel, expandedValues)
+	} else {
+		logger.V(1).Info("Mismatch in expanded label and value counts, skipping metric generation", "labelCount", len(anchor), "valueCount", len(expandedValues))
+	}
+
+	sortLabels(anchor, parallel...)
+
+	return expandedValues
+}
+
+// writeMetricSamplesWithCount writes single or expanded metric values and returns the sample count.
+func writeMetricSamplesWithCount(
+	builder *strings.Builder,
+	name string,
+	kind MetricKind,
+	raw *unstructured.Unstructured,
+	keys, values []string,
+	expanded map[string][]string,
+	value string,
+	logger klog.Logger,
+) (int64, error) {
+	expandedValues := extractAndSortExpandedValues(expanded, logger)
 
 	var sampleCount int64
 
-	i := 0
+	expandedValueIndex := 0
 	writeMetric := func(k, v []string) error {
 		builder.WriteString(kubeCustomResourcePrefix + name)
 
 		currentValue := value
-		if i < len(expandedValues) {
-			currentValue = expandedValues[i]
+		if expandedValueIndex < len(expandedValues) {
+			currentValue = expandedValues[expandedValueIndex]
 		}
 
-		i++
+		expandedValueIndex++
 		sampleCount++
 
 		return writeMetricTo(

--- a/internal/family.go
+++ b/internal/family.go
@@ -183,7 +183,7 @@ func (f *FamilyType) buildMetricString(unstructured *unstructured.Unstructured) 
 
 		resolvedLabelKeys, resolvedLabelValues, resolvedExpandedLabelSet := resolveLabels(metricLabels, resolverInstance, unstructured.Object)
 
-		resolvedValue, ok := resolveMetricValue(resolverInstance, metric.Value, unstructured.Object, resolvedExpandedLabelSet)
+		resolvedValue, ok := resolveMetricValue(resolverInstance, metric.Value, unstructured.Object, &resolvedExpandedLabelSet)
 		if !ok {
 			logger.V(1).Error(fmt.Errorf("error resolving metric value %q", metric.Value), "skipping")
 			putBuilder(metricRawBuilder)
@@ -276,7 +276,7 @@ func inheritMetricLabels(f *FamilyType, metric *v1alpha1.Metric) []v1alpha1.Labe
 // a list (indexed keys like "fieldParent#N"), the values are collected in
 // order and stored in resolvedExpandedLabelSet under the sentinel key so that
 // writeMetricSamples can emit one sample per element.
-func resolveMetricValue(resolverInstance resolver.Resolver, valueExpr string, obj map[string]any, resolvedExpandedLabelSet map[string][]string) (string, bool) {
+func resolveMetricValue(resolverInstance resolver.Resolver, valueExpr string, obj map[string]any, resolvedExpandedLabelSet *map[string][]string) (string, bool) {
 	resolvedValueMap := resolverInstance.Resolve(valueExpr, obj)
 	if resolvedValue, found := resolvedValueMap[valueExpr]; found {
 		return resolvedValue, true
@@ -308,7 +308,7 @@ func resolveMetricValue(resolverInstance resolver.Resolver, valueExpr string, ob
 		return "", false
 	}
 
-	resolvedExpandedLabelSet[expandedValueSentinel] = expandedValues
+	(*resolvedExpandedLabelSet)[expandedValueSentinel] = expandedValues
 
 	return "", true
 }
@@ -337,15 +337,34 @@ func resolveLabels(labels []v1alpha1.Label, resolverInstance resolver.Resolver, 
 			// In this case, map keys become label names directly without concatenation.
 			isMapExpansion := strings.HasPrefix(label.Name, "_")
 
-			for k, v := range resolvedLabelset {
-				// Check if key has a suffix that satisfies the regex: "#\d+".
-				// This is used to identify list values in way that's resolver-agnostic.
-				if listIndexRegex.MatchString(k) {
-					// Use the user-specified label name as the expansion key so the
-					// generated metric carries e.g. `type="Ready"` rather than the
-					// internal field-parent token (e.g. `map="Ready"`).
-					resolvedExpandedLabelSet[sanitizeKey(label.Name)] = append(resolvedExpandedLabelSet[sanitizeKey(label.Name)], v)
+			// Collect list-indexed values in deterministic suffix order (#0, #1, ...)
+			// to match the order used by resolveMetricValue. Map iteration order is
+			// non-deterministic and would decouple labels from their metric values.
+			sanitizedName := sanitizeKey(label.Name)
 
+			for i := 0; ; i++ {
+				suffix := "#" + strconv.Itoa(i)
+
+				var match string
+
+				for k, v := range resolvedLabelset {
+					if strings.HasSuffix(k, suffix) {
+						match = v
+
+						break
+					}
+				}
+
+				if match == "" {
+					break
+				}
+
+				resolvedExpandedLabelSet[sanitizedName] = append(resolvedExpandedLabelSet[sanitizedName], match)
+			}
+
+			// Process non-list entries (map keys, non-composite values).
+			for k, v := range resolvedLabelset {
+				if listIndexRegex.MatchString(k) {
 					continue
 				}
 
@@ -365,21 +384,33 @@ func resolveLabels(labels []v1alpha1.Label, resolverInstance resolver.Resolver, 
 
 	return resolvedLabelKeys, resolvedLabelValues, resolvedExpandedLabelSet
 }
-func sortLabels(keys, values []string) {
-	type kv struct{ k, v string }
 
-	pairs := make([]kv, len(keys))
-	for i := range keys {
-		pairs[i] = kv{keys[i], values[i]}
+// sortLabels sorts keys and applies the same permutation to all parallel slices.
+func sortLabels(keys []string, parallel ...[]string) {
+	indices := make([]int, len(keys))
+	for i := range indices {
+		indices[i] = i
 	}
 
-	slices.SortFunc(pairs, func(a, b kv) int {
-		return strings.Compare(a.k, b.k)
+	slices.SortFunc(indices, func(a, b int) int {
+		return strings.Compare(keys[a], keys[b])
 	})
 
-	for i, p := range pairs {
-		keys[i] = p.k
-		values[i] = p.v
+	reorder := func(s []string) {
+		sorted := make([]string, len(s))
+		for i, idx := range indices {
+			sorted[i] = s[idx]
+		}
+
+		copy(s, sorted)
+	}
+
+	reorder(keys)
+
+	for _, p := range parallel {
+		if len(p) == len(keys) {
+			reorder(p)
+		}
 	}
 }
 
@@ -407,6 +438,33 @@ func writeMetricSamplesWithCount(
 	// lists across resolvers.
 	expandedValues := expanded[expandedValueSentinel]
 	delete(expanded, expandedValueSentinel)
+
+	// Co-sort all expanded arrays (labels + values) to maintain index
+	// correspondence. Without this, sorting label values independently
+	// decouples them from their metric values.
+	if len(expanded) > 0 {
+		var sortKey string
+		for k := range expanded {
+			if sortKey == "" || k < sortKey {
+				sortKey = k
+			}
+		}
+
+		anchor := expanded[sortKey]
+		parallel := make([][]string, 0, len(expanded)+1)
+
+		for k := range expanded {
+			if k != sortKey {
+				parallel = append(parallel, expanded[k])
+			}
+		}
+
+		if len(expandedValues) == len(anchor) {
+			parallel = append(parallel, expandedValues)
+		}
+
+		sortLabels(anchor, parallel...)
+	}
 
 	var sampleCount int64
 
@@ -481,8 +539,6 @@ func writeExpandedSamples(writeFunc func([]string, []string) error, labelKeys, l
 		if len(expanded[k]) > seriesToGenerate {
 			seriesToGenerate = len(expanded[k])
 		}
-
-		slices.Sort(expanded[k])
 	}
 
 	for range seriesToGenerate {

--- a/internal/family.go
+++ b/internal/family.go
@@ -387,7 +387,13 @@ func resolveLabels(labels []v1alpha1.Label, resolverInstance resolver.Resolver, 
 	return resolvedLabelKeys, resolvedLabelValues, resolvedExpandedLabelSet
 }
 
-// sortLabels sorts keys and applies the same permutation to all parallel slices.
+// sortLabels sorts keys alphabetically and applies the same permutation to all
+// parallel slices, so that positionally-correlated data stays aligned with its
+// corresponding key after sorting. For example, given label keys
+// ["Ready", "Degraded", "Progressing"] with label values
+// ["True", "False", "Unknown"], sorting produces keys
+// ["Degraded", "Progressing", "Ready"] and values ["False", "Unknown", "True"],
+// preserving the pairing Degraded→"False", Progressing→"Unknown", Ready→"True".
 func sortLabels(keys []string, parallel ...[]string) {
 	indices := make([]int, len(keys))
 	for i := range indices {
@@ -421,11 +427,11 @@ func sanitizeKey(s string) string {
 	return strcase.ToSnake(nonWordRegex.ReplaceAllString(s, "_"))
 }
 
-// extractAndSortExpandedValues extracts expanded values from the sentinel key and co-sorts them with labels to maintain index correspondence.
+// extractAndSortExpandedMetricValues extracts expanded values from the sentinel key and co-sorts them with labels to maintain index correspondence.
 // The sentinel key is removed from the expanded map after extraction.
 // If there is a length mismatch between the expanded values and labels, a warning is logged and values are not co-sorted to avoid misalignment.
 // If multiple label keys are present, they are co-sorted together based on the anchor key (the lexicographically smallest label key) to maintain their relative order.
-func extractAndSortExpandedValues(expanded map[string][]string, logger klog.Logger) []string {
+func extractAndSortExpandedMetricValues(expanded map[string][]string, logger klog.Logger) []string {
 	// Extract per-sample values stored under the sentinel when the value
 	// expression resolved to a list. The sentinel is not a real label.
 	// NOTE that we do not want resolver-specific logic making its way into
@@ -450,6 +456,12 @@ func extractAndSortExpandedValues(expanded map[string][]string, logger klog.Logg
 	}
 
 	anchor := expanded[sortKey]
+	if len(expandedValues) != len(anchor) {
+		logger.V(1).Info("Mismatch in expanded label and value counts, skipping expanded label sorting", "labelCount", len(anchor), "valueCount", len(expandedValues))
+
+		return expandedValues
+	}
+
 	parallel := make([][]string, 0, len(expanded)+1)
 
 	for k := range expanded {
@@ -458,12 +470,7 @@ func extractAndSortExpandedValues(expanded map[string][]string, logger klog.Logg
 		}
 	}
 
-	if len(expandedValues) == len(anchor) {
-		parallel = append(parallel, expandedValues)
-	} else {
-		logger.V(1).Info("Mismatch in expanded label and value counts, skipping metric generation", "labelCount", len(anchor), "valueCount", len(expandedValues))
-	}
-
+	parallel = append(parallel, expandedValues)
 	sortLabels(anchor, parallel...)
 
 	return expandedValues
@@ -480,7 +487,7 @@ func writeMetricSamplesWithCount(
 	value string,
 	logger klog.Logger,
 ) (int64, error) {
-	expandedValues := extractAndSortExpandedValues(expanded, logger)
+	expandedValues := extractAndSortExpandedMetricValues(expanded, logger)
 
 	var sampleCount int64
 

--- a/internal/family.go
+++ b/internal/family.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"slices"
 	"strconv"
@@ -556,7 +557,9 @@ func writeSingleSample(writeFunc func([]string, []string) error, keys, values []
 func writeExpandedSamples(writeFunc func([]string, []string) error, labelKeys, labelValues []string, expanded map[string][]string, logger klog.Logger) error {
 	var seriesToGenerate int
 
-	for k := range expanded {
+	// Sort expanded keys to ensure deterministic label ordering.
+	// Map iteration order is non-deterministic, so we must sort explicitly.
+	for _, k := range slices.Sorted(maps.Keys(expanded)) {
 		labelKeys = append(labelKeys, k)
 
 		if len(expanded[k]) > seriesToGenerate {

--- a/internal/family_test.go
+++ b/internal/family_test.go
@@ -278,3 +278,65 @@ func Test_extractAndSortExpandedMetricValues(t *testing.T) {
 		})
 	}
 }
+
+func Test_collectIndexedResolvedValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		resolved map[string]string
+		want     []string
+	}{
+		{
+			name:     "empty map returns nil",
+			resolved: map[string]string{},
+			want:     nil,
+		},
+		{
+			name: "collects indexed values in numeric suffix order",
+			resolved: map[string]string{
+				"field#1": "beta",
+				"field#0": "alpha",
+				"field#2": "gamma",
+			},
+			want: []string{"alpha", "beta", "gamma"},
+		},
+		{
+			name: "preserves empty string values",
+			resolved: map[string]string{
+				"field#0": "",
+				"field#1": "present",
+			},
+			want: []string{"", "present"},
+		},
+		{
+			name: "stops at first missing index",
+			resolved: map[string]string{
+				"field#0": "alpha",
+				"field#2": "gamma",
+			},
+			want: []string{"alpha"},
+		},
+		{
+			name: "ignores non indexed keys",
+			resolved: map[string]string{
+				"field":   "scalar",
+				"other#0": "alpha",
+				"misc":    "value",
+			},
+			want: []string{"alpha"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := collectIndexedResolvedValues(tt.resolved)
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("collectIndexedResolvedValues() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/family_test.go
+++ b/internal/family_test.go
@@ -171,7 +171,7 @@ func TestFamilyType_rawFrom(t *testing.T) {
 	}
 }
 
-func Test_extractAndSortExpandedValues(t *testing.T) {
+func Test_extractAndSortExpandedMetricValues(t *testing.T) {
 	t.Parallel()
 
 	logger := klog.Background()
@@ -203,7 +203,7 @@ func Test_extractAndSortExpandedValues(t *testing.T) {
 			},
 			wantValues: nil,
 			wantExpandedAfter: map[string][]string{
-				"type": {"Initialized", "Ready"},
+				"type": {"Ready", "Initialized"},
 			},
 		},
 		{
@@ -254,11 +254,10 @@ func Test_extractAndSortExpandedValues(t *testing.T) {
 				expandedValueSentinel: {"1", "2"},
 				"type":                {"Ready", "Initialized", "PodScheduled"},
 			},
-			// Values are NOT appended to parallel slices due to length mismatch,
-			// but labels are still sorted.
+			// Values are NOT appended to parallel slices due to length mismatch
 			wantValues: []string{"1", "2"},
 			wantExpandedAfter: map[string][]string{
-				"type": {"Initialized", "PodScheduled", "Ready"},
+				"type": {"Ready", "Initialized", "PodScheduled"},
 			},
 		},
 	}
@@ -267,7 +266,7 @@ func Test_extractAndSortExpandedValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := extractAndSortExpandedValues(tt.expanded, logger)
+			got := extractAndSortExpandedMetricValues(tt.expanded, logger)
 
 			if diff := cmp.Diff(tt.wantValues, got); diff != "" {
 				t.Errorf("returned values mismatch (-want +got):\n%s", diff)

--- a/internal/family_test.go
+++ b/internal/family_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package internal
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -33,6 +34,30 @@ func TestFamilyType_rawFrom(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name":      "test-pod",
 				"namespace": "test-namespace",
+			},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "False",
+					},
+					map[string]interface{}{
+						"type":   "ContainersReady",
+						"status": "False",
+					},
+					map[string]interface{}{
+						"status": "True",
+						"type":   "PodReadyToStartContainers",
+					},
+					map[string]interface{}{
+						"status": "False",
+						"type":   "PodScheduled",
+					},
+					map[string]interface{}{
+						"status": "True",
+						"type":   "Initialized",
+					},
+				},
 			},
 		},
 	}
@@ -98,6 +123,34 @@ func TestFamilyType_rawFrom(t *testing.T) {
 				},
 			},
 			expected: "", // No resolver specified, should produce no metrics
+		},
+		{
+			name: "extended Pod status conditions with CEL resolver",
+			family: &FamilyType{
+				Family: v1alpha1.Family{
+					Name: "pod_status_conditions",
+					Help: "Condition status for each pod instance",
+					Metrics: []v1alpha1.Metric{
+						{
+							Labels: []v1alpha1.Label{
+								{
+									Name:  "type",
+									Value: "o.status.conditions.map(c, c.type)",
+								},
+							},
+							Value:    "o.status.conditions.map(c, int(c.status == 'True' ? 1 : 0))",
+							Resolver: v1alpha1.ResolverTypeCEL,
+						},
+					},
+				},
+			},
+			expected: strings.Join([]string{
+				"kube_customresource_pod_status_conditions{type=\"ContainersReady\",group=\"\",version=\"v1\",kind=\"Pod\",name=\"test-pod\",namespace=\"test-namespace\"} 0.000000",
+				"kube_customresource_pod_status_conditions{type=\"Initialized\",group=\"\",version=\"v1\",kind=\"Pod\",name=\"test-pod\",namespace=\"test-namespace\"} 1.000000",
+				"kube_customresource_pod_status_conditions{type=\"PodReadyToStartContainers\",group=\"\",version=\"v1\",kind=\"Pod\",name=\"test-pod\",namespace=\"test-namespace\"} 1.000000",
+				"kube_customresource_pod_status_conditions{type=\"PodScheduled\",group=\"\",version=\"v1\",kind=\"Pod\",name=\"test-pod\",namespace=\"test-namespace\"} 0.000000",
+				"kube_customresource_pod_status_conditions{type=\"Ready\",group=\"\",version=\"v1\",kind=\"Pod\",name=\"test-pod\",namespace=\"test-namespace\"} 0.000000",
+			}, "\n") + "\n",
 		},
 	}
 

--- a/internal/family_test.go
+++ b/internal/family_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/kubernetes-sigs/resource-state-metrics/pkg/apis/resourcestatemetrics/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
 )
 
 func TestFamilyType_rawFrom(t *testing.T) {
@@ -165,6 +166,115 @@ func TestFamilyType_rawFrom(t *testing.T) {
 			// Verify sample count is reasonable (should be at least 1 for non-empty results)
 			if tt.expected != "" && sampleCount == 0 {
 				t.Errorf("expected non-zero sample count for non-empty metric string")
+			}
+		})
+	}
+}
+
+func Test_extractAndSortExpandedValues(t *testing.T) {
+	t.Parallel()
+
+	logger := klog.Background()
+
+	tests := []struct {
+		name              string
+		expanded          map[string][]string
+		wantValues        []string
+		wantExpandedAfter map[string][]string // expected state of expanded map after call
+	}{
+		{
+			name:              "empty map returns nil",
+			expanded:          map[string][]string{},
+			wantValues:        nil,
+			wantExpandedAfter: map[string][]string{},
+		},
+		{
+			name: "sentinel only, no labels",
+			expanded: map[string][]string{
+				expandedValueSentinel: {"10", "20", "30"},
+			},
+			wantValues:        []string{"10", "20", "30"},
+			wantExpandedAfter: map[string][]string{},
+		},
+		{
+			name: "labels only, no sentinel",
+			expanded: map[string][]string{
+				"type": {"Ready", "Initialized"},
+			},
+			wantValues: nil,
+			wantExpandedAfter: map[string][]string{
+				"type": {"Initialized", "Ready"},
+			},
+		},
+		{
+			name: "co-sorts labels and values by anchor key",
+			expanded: map[string][]string{
+				expandedValueSentinel: {"1", "0"},
+				"type":                {"Ready", "Initialized"},
+			},
+			wantValues: []string{"0", "1"},
+			wantExpandedAfter: map[string][]string{
+				"type": {"Initialized", "Ready"},
+			},
+		},
+		{
+			name: "multiple label keys co-sorted together",
+			expanded: map[string][]string{
+				expandedValueSentinel: {"100", "200", "300"},
+				"node":                {"compute-2", "control-plane-1", "compute-1"},
+				"zone":                {"us-east", "eu-west", "ap-south"},
+			},
+			wantValues: []string{"300", "100", "200"},
+			wantExpandedAfter: map[string][]string{
+				"node": {"compute-1", "compute-2", "control-plane-1"},
+				"zone": {"ap-south", "us-east", "eu-west"},
+			},
+		},
+		{
+			name: "anchor key is the lexicographically smallest label key",
+			expanded: map[string][]string{
+				expandedValueSentinel: {"500", "100", "300"},
+				// "app" < "node" < "zone" lexicographically, so "app" is the anchor.
+				// Sorting by "app" values: ["beta", "alpha", "gamma"] -> indices [1,0,2]
+				// produces: app=["alpha","beta","gamma"], node=["n2","n1","n3"], zone=["z2","z1","z3"], values=["100","500","300"]
+				"zone": {"z1", "z2", "z3"},
+				"node": {"n1", "n2", "n3"},
+				"app":  {"beta", "alpha", "gamma"},
+			},
+			wantValues: []string{"100", "500", "300"},
+			wantExpandedAfter: map[string][]string{
+				"app":  {"alpha", "beta", "gamma"},
+				"node": {"n2", "n1", "n3"},
+				"zone": {"z2", "z1", "z3"},
+			},
+		},
+		{
+			name: "mismatched value and label counts logs warning",
+			expanded: map[string][]string{
+				expandedValueSentinel: {"1", "2"},
+				"type":                {"Ready", "Initialized", "PodScheduled"},
+			},
+			// Values are NOT appended to parallel slices due to length mismatch,
+			// but labels are still sorted.
+			wantValues: []string{"1", "2"},
+			wantExpandedAfter: map[string][]string{
+				"type": {"Initialized", "PodScheduled", "Ready"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := extractAndSortExpandedValues(tt.expanded, logger)
+
+			if diff := cmp.Diff(tt.wantValues, got); diff != "" {
+				t.Errorf("returned values mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tt.wantExpandedAfter, tt.expanded); diff != "" {
+				t.Errorf("expanded map state mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/tests/golden/cel/resourcemetricsmonitor-anchor-key.yaml
+++ b/tests/golden/cel/resourcemetricsmonitor-anchor-key.yaml
@@ -1,0 +1,76 @@
+---
+# Copyright 2026 The Kubernetes resource-state-metrics Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: resourcemetricsmonitor-bars-anchor-key
+description: >
+  Tests that multiple expanded label keys are co-sorted by the anchor key
+  (the lexicographically smallest label key name). Here "reason" < "type",
+  so sorting is driven by the "reason" values. This ensures that labels and
+  metric values maintain correct positional correspondence after sorting.
+  For example, reason="Ready" must pair with type="Ready" and value=1,
+  not with an unrelated type or value from a different list position.
+in:
+  apiVersion: resource-state-metrics.instrumentation.k8s-sigs.io/v1alpha1
+  kind: ResourceMetricsMonitor
+  metadata:
+    name: resourcemetricsmonitor-bars-anchor-key
+    namespace: default
+  spec:
+    configuration:
+      stores:
+        - group: "samplecontroller.k8s.io"
+          version: "v1beta1"
+          kind: "Bar"
+          resource: "bars"
+          families:
+            - name: "bars_conditions_anchor_key"
+              help: "Condition status with multiple expanded labels to verify anchor key sorting"
+              metrics:
+                - resolver: "cel"
+                  labels:
+                    - name: "reason"
+                      value: "o.spec.conditions.map(c, c.reason)"
+                    - name: "type"
+                      value: "o.spec.conditions.map(c, c.type)"
+                  value: "o.spec.conditions.map(c, int(c.status == 'True' ? 1 : 0))"
+metrics:
+  - "# HELP kube_customresource_bars_conditions_anchor_key Condition status with multiple expanded labels to verify anchor key sorting"
+  - "# TYPE kube_customresource_bars_conditions_anchor_key gauge"
+  # test-sample: conditions are [{Ready,True,Ready},{Degraded,False,Working},{Progressing,Unknown,Reconciling}]
+  # Anchor key is "reason" (lexicographically smallest). Sorting by reason values:
+  #   "Ready" < "Reconciling" < "Working" → reorders positions [0,2,1]
+  #   reason=["Ready","Reconciling","Working"], type=["Ready","Progressing","Degraded"], values=[1,0,0]
+  - 'kube_customresource_bars_conditions_anchor_key{reason="Ready",type="Ready",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample",namespace="default"} 1.000000'
+  - 'kube_customresource_bars_conditions_anchor_key{reason="Reconciling",type="Progressing",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample",namespace="default"} 0.000000'
+  - 'kube_customresource_bars_conditions_anchor_key{reason="Working",type="Degraded",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample",namespace="default"} 0.000000'
+  # test-sample-secondary: conditions are [{Ready,False,NotReady},{Degraded,True,ConfigError},{Progressing,True,Reconciling}]
+  # Sorting by reason: "ConfigError" < "NotReady" < "Reconciling" → reorders positions [1,0,2]
+  #   reason=["ConfigError","NotReady","Reconciling"], type=["Degraded","Ready","Progressing"], values=[1,0,1]
+  - 'kube_customresource_bars_conditions_anchor_key{reason="ConfigError",type="Degraded",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample-secondary",namespace="default"} 1.000000'
+  - 'kube_customresource_bars_conditions_anchor_key{reason="NotReady",type="Ready",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample-secondary",namespace="default"} 0.000000'
+  - 'kube_customresource_bars_conditions_anchor_key{reason="Reconciling",type="Progressing",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample-secondary",namespace="default"} 1.000000'
+status:
+  cardinality:
+    total: 6
+    thresholdsExceeded: false
+  conditions:
+    - type: Processed
+      status: "True"
+      reason: EventHandlerSucceeded
+    - type: CardinalityCutoff
+      status: "False"
+      reason: CardinalityOK
+    - type: CardinalityWarning
+      status: "False"
+      reason: CardinalityOK

--- a/tests/manifests/custom-resource/custom-resource-bars-secondary.yaml
+++ b/tests/manifests/custom-resource/custom-resource-bars-secondary.yaml
@@ -28,12 +28,12 @@ spec:
   environmentType: dev
   replicas: 1
   conditions:
+    - type: Ready
+      status: "False"
+      reason: NotReady
     - type: Degraded
       status: "True"
       reason: ConfigError
     - type: Progressing
       status: "True"
       reason: Reconciling
-    - type: Ready
-      status: "False"
-      reason: NotReady

--- a/tests/manifests/custom-resource/custom-resource-bars.yaml
+++ b/tests/manifests/custom-resource/custom-resource-bars.yaml
@@ -43,15 +43,15 @@ spec:
     - "3.0"
     - "4.0"
   conditions:
+    - type: Ready
+      status: "True"
+      reason: Ready
     - type: Degraded
       status: "False"
       reason: Working
     - type: Progressing
       status: "Unknown"
       reason: Reconciling
-    - type: Ready
-      status: "True"
-      reason: Ready
   xProps:
     nonComposite: "example-value"
     compositeArray:


### PR DESCRIPTION
## Summary

The patch changes `resolveLabels` to use the same sequential index lookup pattern as `resolveMetricValue`.
This ensures labels and values always correspond by position.

To make the issue more clear, I've done two separate commits where I've extended the tests first.
Second commit is a suggestion.

As there is no sorting guarantee in list-objects and we do a sorting in
the labelvalues, we didn't apply the same sorting logic to the metric
values. This leads to a wrong value to label mapping.

Test output from my additional test-cases from the first commit - https://github.com/kubernetes-sigs/resource-state-metrics/pull/22/changes/d9c4e8d66b3ab003c506f7752eb90ad2f990a871:

```
 go test ./...                                                                                                                                                                                     
?       github.com/kubernetes-sigs/resource-state-metrics       [no test files]                                                                                                                     
?       github.com/kubernetes-sigs/resource-state-metrics/external      [no test files]                                                                                                             
--- FAIL: TestFamilyType_rawFrom (0.00s)                                                                                                                                                            
    --- FAIL: TestFamilyType_rawFrom/extended_Pod_status_conditions_with_CEL_resolver (0.00s)                                                                                                       
        family_test.go:163: kube_customresource_pod_status_conditions{type="ContainersReady",group="",version="v1",kind="Pod",name="test-pod",namespace="test-namespace"} 0.000000                  
            kube_customresource_pod_status_conditions{type="Initialized",group="",version="v1",kind="Pod",name="test-pod",namespace="test-namespace"} 0.000000                                      
            kube_customresource_pod_status_conditions{type="PodReadyToStartContainers",group="",version="v1",kind="Pod",name="test-pod",namespace="test-namespace"} 1.000000                        
            kube_customresource_pod_status_conditions{type="PodScheduled",group="",version="v1",kind="Pod",name="test-pod",namespace="test-namespace"} 0.000000                                     
            kube_customresource_pod_status_conditions{type="Ready",group="",version="v1",kind="Pod",name="test-pod",namespace="test-namespace"} 1.000000                                            
                                                                                                                                                                                                    
              strings.Join({                                                                                                                                                                        
                ... // 161 identical bytes                                                                                                                                                          
                `mresource_pod_status_conditions{type="Initialized",group="",vers`,                                                                                                                 
                `ion="v1",kind="Pod",name="test-pod",namespace="test-namespace"} `,                                                                                                                 
            -   "0",                                                                                                                                                                                
            +   "1",                                                                                                                                                                                
                ".000000\nkube_customresource_pod_status_conditions{type=\"PodReady",                                                                                                               
                `ToStartContainers",group="",version="v1",kind="Pod",name="test-p`,                                                                                                                 
                ... // 193 identical bytes                                                                                                                                                          
                `_customresource_pod_status_conditions{type="Ready",group="",vers`,                                                                                                                 
                `ion="v1",kind="Pod",name="test-pod",namespace="test-namespace"} `,                                                                                                                 
            -   "1",                                                                                                                                                                                
            +   "0",                                                                                                                                                                                
                ".000000\n",                                                                                                                                                                        
              }, "")                                                                                                                                                                                
FAIL                                                                                                                                                                                                
FAIL    github.com/kubernetes-sigs/resource-state-metrics/internal      0.076s                                                                                                                      
?       github.com/kubernetes-sigs/resource-state-metrics/internal/version      [no test files]                                                                                                     
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/apis/resourcestatemetrics [no test files]                                                                                             
ok      github.com/kubernetes-sigs/resource-state-metrics/pkg/apis/resourcestatemetrics/v1alpha1        (cached)                                                                                    
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/generated/clientset/versioned     [no test files]                                                                                     
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/generated/clientset/versioned/fake        [no test files]                                                                             
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/generated/clientset/versioned/scheme      [no test files]                                                                             
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/generated/clientset/versioned/typed/resourcestatemetrics/v1alpha1 [no test files]                                                     
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/generated/clientset/versioned/typed/resourcestatemetrics/v1alpha1/fake    [no test files]                                             
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/generated/informers/externalversions      [no test files]                                                                             
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/generated/informers/externalversions/internalinterfaces   [no test files]                                                             
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/generated/informers/externalversions/resourcestatemetrics [no test files]                                                             
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/generated/informers/externalversions/resourcestatemetrics/v1alpha1        [no test files]                                             
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/generated/listers/resourcestatemetrics/v1alpha1   [no test files]                                                                     
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/metricutil        [no test files]                                                                                                     
ok      github.com/kubernetes-sigs/resource-state-metrics/pkg/options   (cached)                                                                                                                    
ok      github.com/kubernetes-sigs/resource-state-metrics/pkg/resolver  (cached)                                                                                                                    
?       github.com/kubernetes-sigs/resource-state-metrics/pkg/signals   [no test files]                                                                                                             
I0430 09:23:09.730346  427312 collector.go:77] "Registered external collectors" collectors=[]                                                                                                       
I0430 09:23:09.730408  427312 collector.go:77] "Registered external collectors" collectors=[]                                                                                                       
--- FAIL: TestGoldenRules (0.66s)                                                                 
    --- FAIL: TestGoldenRules/cel (10.20s)                                                        
        --- FAIL: TestGoldenRules/cel/resourcemetricsmonitor-map (5.10s)                                                                                                                            
            goldenrules_test.go:239: Metric comparison failed:  # HELP kube_customresource_bars_conditions Condition status for each Bar instance                                                   
                 # TYPE kube_customresource_bars_conditions gauge                                                                                                                                   
                -kube_customresource_bars_conditions{type="Degraded",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample",namespace="default"} 1                         
                -kube_customresource_bars_conditions{type="Degraded",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample-secondary",namespace="default"} 0               
                +kube_customresource_bars_conditions{type="Degraded",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample",namespace="default"} 0                         
                +kube_customresource_bars_conditions{type="Degraded",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample-secondary",namespace="default"} 1               
                 kube_customresource_bars_conditions{type="Progressing",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample",namespace="default"} 0                      
                 kube_customresource_bars_conditions{type="Progressing",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample-secondary",namespace="default"} 1
                -kube_customresource_bars_conditions{type="Ready",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample",namespace="default"} 0                            
                -kube_customresource_bars_conditions{type="Ready",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample-secondary",namespace="default"} 1                  
                +kube_customresource_bars_conditions{type="Ready",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample",namespace="default"} 1                            
                +kube_customresource_bars_conditions{type="Ready",group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample-secondary",namespace="default"} 0                  
                                                                                                  
FAIL                                                                                              
FAIL    github.com/kubernetes-sigs/resource-state-metrics/tests 46.605s                                                                                                                             
?       github.com/kubernetes-sigs/resource-state-metrics/tests/framework       [no test files]                                                                                                     
FAIL   
```

<!-- Fixes # -->

## Checklist

- [x] `make verify` passes
- [x] Documentation updated (if applicable)
- [x] Tests added or updated (if applicable)
