### PR TITLE
feat: Aggregated ClusterRole for resource-state-metrics

### DIFF
--- a/hack/generate-yamls-from-jsonnets.sh
+++ b/hack/generate-yamls-from-jsonnets.sh
@@ -47,6 +47,8 @@ local rsm = (import \"jsonnet/resource-state-metrics/resource-state-metrics.libs
   image:: \"registry.k8s.io/${PROJECT_NAME}/${PROJECT_NAME}:v${VERSION}\",
 };
 {
+  \"cluster-role-binding-aggregated\": rsm.aggregatedClusterRoleBinding,
+  \"cluster-role-aggregated\": rsm.aggregatedClusterRole,
   \"cluster-role-binding\": rsm.clusterRoleBinding,
   \"deployment\": rsm.deployment,
   \"service\": rsm.service,
@@ -82,7 +84,7 @@ $YQ -i ".metadata.labels = {
 
 # Copy jsonnet-generated manifests to manifests/ for a complete deployment set
 echo "Copying jsonnet manifests to manifests/"
-for file in cluster-role-binding.yaml deployment.yaml service.yaml service-account.yaml; do
+for file in cluster-role-aggregated.yaml cluster-role-binding-aggregated.yaml cluster-role-binding.yaml deployment.yaml service.yaml service-account.yaml; do
     cp "${OUTPUT_DIR}/${file}" "manifests/${file}"
     echo "  ${file}"
 done

--- a/jsonnet/manifests/cluster-role-aggregated.yaml
+++ b/jsonnet/manifests/cluster-role-aggregated.yaml
@@ -1,0 +1,26 @@
+# Copyright 2026 The Kubernetes resource-state-metrics Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      resource-state-metrics.instrumentation.k8s-sigs.io/aggregate-to-exporter: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: resource-state-metrics
+    app.kubernetes.io/version: 0.0.1
+  name: resource-state-metrics-aggregated

--- a/jsonnet/manifests/cluster-role-binding-aggregated.yaml
+++ b/jsonnet/manifests/cluster-role-binding-aggregated.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 The Kubernetes resource-state-metrics Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: resource-state-metrics
+    app.kubernetes.io/version: 0.0.1
+  name: resource-state-metrics-aggregated
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: resource-state-metrics-aggregated
+subjects:
+- kind: ServiceAccount
+  name: resource-state-metrics
+  namespace: default

--- a/jsonnet/resource-state-metrics/resource-state-metrics.libsonnet
+++ b/jsonnet/resource-state-metrics/resource-state-metrics.libsonnet
@@ -28,12 +28,35 @@
     'app.kubernetes.io/component': 'exporter',
   },
 
+  rbacAggregationLabel:: {
+    'resource-state-metrics.instrumentation.k8s-sigs.io/aggregate-to-exporter': 'true'
+  },
+
   podLabels:: {
     [labelName]: rsm.commonLabels[labelName]
     for labelName in std.objectFields(rsm.commonLabels)
     if !std.setMember(labelName, ['app.kubernetes.io/version'])
   },
 
+  aggregatedClusterRoleBinding:
+    {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
+      metadata: {
+        name: 'resource-state-metrics-aggregated',
+        labels: rsm.commonLabels + rsm.extraRecommendedLabels,
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: 'resource-state-metrics-aggregated',
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: rsm.name,
+        namespace: rsm.namespace,
+      }],
+    },
   clusterRoleBinding:
     {
       apiVersion: 'rbac.authorization.k8s.io/v1',
@@ -96,6 +119,26 @@
         labels: rsm.commonLabels + rsm.extraRecommendedLabels,
       },
       rules: rules,
+    },
+
+  // Aggregated ClusterRole enables simple aggregation of permissions to the exporter
+  aggregatedClusterRole:
+    local aggregationRule = {
+      clusterRoleSelectors: [
+        {
+          matchLabels: rsm.rbacAggregationLabel,
+        },
+      ],
+    };
+
+    {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: {
+        name: 'resource-state-metrics-aggregated',
+        labels: rsm.commonLabels + rsm.extraRecommendedLabels,
+      },
+      aggregationRule: aggregationRule,
     },
 
   deployment:

--- a/manifests/cluster-role-aggregated.yaml
+++ b/manifests/cluster-role-aggregated.yaml
@@ -1,0 +1,26 @@
+# Copyright 2026 The Kubernetes resource-state-metrics Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      resource-state-metrics.instrumentation.k8s-sigs.io/aggregate-to-exporter: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: resource-state-metrics
+    app.kubernetes.io/version: 0.0.1
+  name: resource-state-metrics-aggregated

--- a/manifests/cluster-role-binding-aggregated.yaml
+++ b/manifests/cluster-role-binding-aggregated.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 The Kubernetes resource-state-metrics Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: resource-state-metrics
+    app.kubernetes.io/version: 0.0.1
+  name: resource-state-metrics-aggregated
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: resource-state-metrics-aggregated
+subjects:
+- kind: ServiceAccount
+  name: resource-state-metrics
+  namespace: default


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/resource-state-metrics/issues/17

## Summary


Adds a new clusterrole and clusterrolebinding using [aggregated clusterroles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles) to provide easy extensibiulity of the RSM RBAC permissions to users 

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)
