### PR TITLE
feat: add now()/time module for duration calculations in CEL and Starlark resolvers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
-ARG TARGETOS
-ARG TARGETARCH
+# Default TARGETOS/TARGETARCH so plain `docker build` (BuildKit disabled, no
+# buildx) does not expand them empty and feed `GOOS= GOARCH=` to the toolchain.
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
+# BUILDPLATFORM/TARGETOS/TARGETARCH are populated automatically by BuildKit.
+# Declare defaults so plain `docker build` (BuildKit disabled, no buildx) does
+# not expand them empty and feed `--platform=` / `GOOS= GOARCH=` downstream.
+ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
-# Default TARGETOS/TARGETARCH so plain `docker build` (BuildKit disabled, no
-# buildx) does not expand them empty and feed `GOOS= GOARCH=` to the toolchain.
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 
@@ -13,7 +15,10 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH make resource-state-metrics
+# -B forces a rebuild: the `resource-state-metrics` target is file-based, not
+# phony, so a binary copied in from the build context (no .dockerignore) would
+# otherwise satisfy the timestamp check and ignore GOOS/GOARCH.
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH make -B resource-state-metrics
 
 FROM ubuntu:24.04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /
 
@@ -8,7 +11,7 @@ RUN go mod download
 
 COPY . .
 
-RUN make resource-state-metrics
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH make resource-state-metrics
 
 FROM ubuntu:24.04
 

--- a/manifests/custom-resource-definition.yaml
+++ b/manifests/custom-resource-definition.yaml
@@ -201,6 +201,13 @@ spec:
                                       Script is the inline Starlark script source code.
                                       The script has access to `obj` (the resource as a dict) and built-in functions:
                                       - quantity_to_float(s): Parse Kubernetes Quantity ("100m", "1Gi") to float
+                                      - timestamp(): Current time as Unix epoch seconds (float)
+                                      - parse_time(s): Parse an RFC-3339 / RFC-3339Nano timestamp string
+                                        (e.g. condition.lastTransitionTime) to Unix epoch seconds. Empty
+                                        input returns 0.0; malformed non-empty input is an error. Combined
+                                        with timestamp(), this enables duration-based metrics like "how
+                                        long has this resource held its current condition status".
+                                      - label_prefix(prefix, labels): Prefix and sanitize a label dict's keys
                                       - metric(labels, value): Create a sample with labels dict and float value
                                       - family(name, help, kind, samples): Create a family with list of samples
                                     minLength: 1

--- a/manifests/custom-resource-definition.yaml
+++ b/manifests/custom-resource-definition.yaml
@@ -201,12 +201,14 @@ spec:
                                       Script is the inline Starlark script source code.
                                       The script has access to `obj` (the resource as a dict) and built-in functions:
                                       - quantity_to_float(s): Parse Kubernetes Quantity ("100m", "1Gi") to float
-                                      - timestamp(): Current time as Unix epoch seconds (float)
-                                      - parse_time(s): Parse an RFC-3339 / RFC-3339Nano timestamp string
-                                        (e.g. condition.lastTransitionTime) to Unix epoch seconds. Empty
-                                        input returns 0.0; malformed non-empty input is an error. Combined
-                                        with timestamp(), this enables duration-based metrics like "how
-                                        long has this resource held its current condition status".
+                                      - time: starlark-go's time module (https://pkg.go.dev/go.starlark.net/lib/time).
+                                        Notable entries: time.now() returns the current time.time; time.parse_time(s)
+                                        parses an RFC-3339 string (e.g. condition.lastTransitionTime) into a time.time;
+                                        subtracting two time.time values yields a time.duration whose .seconds
+                                        attribute is a float. Example duration-since-transition pattern:
+                                        `(time.now() - time.parse_time(c["lastTransitionTime"])).seconds`.
+                                        Note: time.parse_time errors on empty input, so guard with
+                                        `if not ts: continue` before calling it.
                                       - label_prefix(prefix, labels): Prefix and sanitize a label dict's keys
                                       - metric(labels, value): Create a sample with labels dict and float value
                                       - family(name, help, kind, samples): Create a family with list of samples

--- a/pkg/apis/resourcestatemetrics/v1alpha1/types.go
+++ b/pkg/apis/resourcestatemetrics/v1alpha1/types.go
@@ -116,6 +116,13 @@ type StarlarkConfig struct {
 	// Script is the inline Starlark script source code.
 	// The script has access to `obj` (the resource as a dict) and built-in functions:
 	// - quantity_to_float(s): Parse Kubernetes Quantity ("100m", "1Gi") to float
+	// - timestamp(): Current time as Unix epoch seconds (float)
+	// - parse_time(s): Parse an RFC-3339 / RFC-3339Nano timestamp string
+	//   (e.g. condition.lastTransitionTime) to Unix epoch seconds. Empty
+	//   input returns 0.0; malformed non-empty input is an error. Combined
+	//   with timestamp(), this enables duration-based metrics like "how
+	//   long has this resource held its current condition status".
+	// - label_prefix(prefix, labels): Prefix and sanitize a label dict's keys
 	// - metric(labels, value): Create a sample with labels dict and float value
 	// - family(name, help, kind, samples): Create a family with list of samples
 	// +kubebuilder:validation:Required

--- a/pkg/apis/resourcestatemetrics/v1alpha1/types.go
+++ b/pkg/apis/resourcestatemetrics/v1alpha1/types.go
@@ -116,12 +116,14 @@ type StarlarkConfig struct {
 	// Script is the inline Starlark script source code.
 	// The script has access to `obj` (the resource as a dict) and built-in functions:
 	// - quantity_to_float(s): Parse Kubernetes Quantity ("100m", "1Gi") to float
-	// - timestamp(): Current time as Unix epoch seconds (float)
-	// - parse_time(s): Parse an RFC-3339 / RFC-3339Nano timestamp string
-	//   (e.g. condition.lastTransitionTime) to Unix epoch seconds. Empty
-	//   input returns 0.0; malformed non-empty input is an error. Combined
-	//   with timestamp(), this enables duration-based metrics like "how
-	//   long has this resource held its current condition status".
+	// - time: starlark-go's time module (https://pkg.go.dev/go.starlark.net/lib/time).
+	//   Notable entries: time.now() returns the current time.time; time.parse_time(s)
+	//   parses an RFC-3339 string (e.g. condition.lastTransitionTime) into a time.time;
+	//   subtracting two time.time values yields a time.duration whose .seconds
+	//   attribute is a float. Example duration-since-transition pattern:
+	//   `(time.now() - time.parse_time(c["lastTransitionTime"])).seconds`.
+	//   Note: time.parse_time errors on empty input, so guard with
+	//   `if not ts: continue` before calling it.
 	// - label_prefix(prefix, labels): Prefix and sanitize a label dict's keys
 	// - metric(labels, value): Create a sample with labels dict and float value
 	// - family(name, help, kind, samples): Create a family with list of samples

--- a/pkg/resolver/cel.go
+++ b/pkg/resolver/cel.go
@@ -76,6 +76,7 @@ const (
 	celCostUnixSeconds uint64 = 10
 	celCostQuantity    uint64 = 10
 	celCostLabelPrefix uint64 = 20
+	celCostTimestamp   uint64 = 1
 )
 
 // CallCost sets the runtime cost for CEL queries on a per-function basis.
@@ -84,6 +85,7 @@ func (ce costEstimator) CallCost(function string, _ string, _ []ref.Val, _ ref.V
 		"unixSeconds": celCostUnixSeconds,
 		"quantity":    celCostQuantity,
 		"labelPrefix": celCostLabelPrefix,
+		"timestamp":   celCostTimestamp,
 	}
 	estimatedCost := 1 + customFunctionsCosts[function]
 
@@ -195,6 +197,13 @@ func (cr *CELResolver) createEnvironment() (*cel.Env, error) {
 				cel.BinaryBinding(labelPrefixBinding),
 			),
 		),
+		cel.Function("timestamp",
+			cel.Overload("timestamp_void",
+				[]*cel.Type{},
+				cel.DoubleType,
+				cel.FunctionBinding(timestampBinding),
+			),
+		),
 	)
 }
 
@@ -280,6 +289,14 @@ func labelPrefixBinding(lhs, rhs ref.Val) ref.Val {
 	}
 
 	return types.NewStringStringMap(types.DefaultTypeAdapter, result)
+}
+
+// timestampBinding implements the logic for the timestamp function, which
+// returns the current time as Unix seconds (a double). This enables computing
+// durations by subtracting a resource's lastTransitionTime from the current
+// time, e.g., `timestamp() - unixSeconds(o.status.conditions[0].lastTransitionTime)`.
+func timestampBinding(_ ...ref.Val) ref.Val {
+	return types.Double(float64(time.Now().Unix()))
 }
 
 func (cr *CELResolver) compileProgram(env *cel.Env, ast *cel.Ast) (cel.Program, error) {

--- a/pkg/resolver/cel.go
+++ b/pkg/resolver/cel.go
@@ -76,7 +76,7 @@ const (
 	celCostUnixSeconds uint64 = 10
 	celCostQuantity    uint64 = 10
 	celCostLabelPrefix uint64 = 20
-	celCostTimestamp   uint64 = 1
+	celCostNow         uint64 = 1
 )
 
 // CallCost sets the runtime cost for CEL queries on a per-function basis.
@@ -85,7 +85,7 @@ func (ce costEstimator) CallCost(function string, _ string, _ []ref.Val, _ ref.V
 		"unixSeconds": celCostUnixSeconds,
 		"quantity":    celCostQuantity,
 		"labelPrefix": celCostLabelPrefix,
-		"timestamp":   celCostTimestamp,
+		"now":         celCostNow,
 	}
 	estimatedCost := 1 + customFunctionsCosts[function]
 
@@ -197,11 +197,11 @@ func (cr *CELResolver) createEnvironment() (*cel.Env, error) {
 				cel.BinaryBinding(labelPrefixBinding),
 			),
 		),
-		cel.Function("timestamp",
-			cel.Overload("timestamp_void",
+		cel.Function("now",
+			cel.Overload("now_void",
 				[]*cel.Type{},
 				cel.DoubleType,
-				cel.FunctionBinding(timestampBinding),
+				cel.FunctionBinding(nowBinding),
 			),
 		),
 	)
@@ -291,11 +291,13 @@ func labelPrefixBinding(lhs, rhs ref.Val) ref.Val {
 	return types.NewStringStringMap(types.DefaultTypeAdapter, result)
 }
 
-// timestampBinding implements the logic for the timestamp function, which
-// returns the current time as Unix seconds (a double). This enables computing
-// durations by subtracting a resource's lastTransitionTime from the current
-// time, e.g., `timestamp() - unixSeconds(o.status.conditions[0].lastTransitionTime)`.
-func timestampBinding(_ ...ref.Val) ref.Val {
+// nowBinding implements the logic for the now function, which returns the
+// current time as Unix seconds (a double). This enables computing durations
+// by subtracting a resource's lastTransitionTime from the current time,
+// e.g., `now() - unixSeconds(o.status.conditions[0].lastTransitionTime)`.
+// Named `now` rather than `timestamp` so we do not shadow CEL's built-in
+// `timestamp(string)` cast.
+func nowBinding(_ ...ref.Val) ref.Val {
 	return types.Double(float64(time.Now().Unix()))
 }
 

--- a/pkg/resolver/cel_test.go
+++ b/pkg/resolver/cel_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package resolver
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -264,6 +265,54 @@ func TestCELResolver_Quantity(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCELResolver_Timestamp(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewCELResolver(klog.NewKlogr(), 10e5, 5*time.Second, nil, "test-ns", "test-rmm", "test-family")
+
+	t.Run("returns current unix seconds", func(t *testing.T) {
+		t.Parallel()
+
+		got := resolver.Resolve(`timestamp()`, map[string]any{})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(got))
+		}
+
+		for _, v := range got {
+			f, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				t.Fatalf("expected numeric result, got %q: %v", v, err)
+			}
+
+			// Should be a reasonable Unix epoch (after 2024-01-01)
+			if f < 1704067200 {
+				t.Errorf("timestamp %f is too small (before 2024-01-01)", f)
+			}
+		}
+	})
+
+	t.Run("compute duration since transition", func(t *testing.T) {
+		t.Parallel()
+
+		got := resolver.Resolve(`timestamp() - unixSeconds(o.timestamp)`, map[string]any{"timestamp": "2024-01-15T10:30:00Z"})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(got))
+		}
+
+		for _, v := range got {
+			f, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				t.Fatalf("expected numeric result, got %q: %v", v, err)
+			}
+
+			// Duration since 2024-01-15 should be positive
+			if f <= 0 {
+				t.Errorf("expected positive duration, got %f", f)
+			}
+		}
+	})
 }
 
 func TestCELResolver_LabelPrefix(t *testing.T) {

--- a/pkg/resolver/cel_test.go
+++ b/pkg/resolver/cel_test.go
@@ -267,7 +267,7 @@ func TestCELResolver_Quantity(t *testing.T) {
 	}
 }
 
-func TestCELResolver_Timestamp(t *testing.T) {
+func TestCELResolver_Now(t *testing.T) {
 	t.Parallel()
 
 	resolver := NewCELResolver(klog.NewKlogr(), 10e5, 5*time.Second, nil, "test-ns", "test-rmm", "test-family")
@@ -275,7 +275,10 @@ func TestCELResolver_Timestamp(t *testing.T) {
 	t.Run("returns current unix seconds", func(t *testing.T) {
 		t.Parallel()
 
-		got := resolver.Resolve(`timestamp()`, map[string]any{})
+		before := time.Now().Unix()
+		got := resolver.Resolve(`now()`, map[string]any{})
+		after := time.Now().Unix()
+
 		if len(got) != 1 {
 			t.Fatalf("expected 1 result, got %d", len(got))
 		}
@@ -286,9 +289,11 @@ func TestCELResolver_Timestamp(t *testing.T) {
 				t.Fatalf("expected numeric result, got %q: %v", v, err)
 			}
 
-			// Should be a reasonable Unix epoch (after 2024-01-01)
-			if f < 1704067200 {
-				t.Errorf("timestamp %f is too small (before 2024-01-01)", f)
+			// Allow a 5-second slop around the call window — pinning to a
+			// calendar date ages badly under clock skew or backdated runners.
+			const delta = 5.0
+			if f < float64(before)-delta || f > float64(after)+delta {
+				t.Errorf("now() = %f, expected within [%d-%g, %d+%g]", f, before, delta, after, delta)
 			}
 		}
 	})
@@ -296,7 +301,7 @@ func TestCELResolver_Timestamp(t *testing.T) {
 	t.Run("compute duration since transition", func(t *testing.T) {
 		t.Parallel()
 
-		got := resolver.Resolve(`timestamp() - unixSeconds(o.timestamp)`, map[string]any{"timestamp": "2024-01-15T10:30:00Z"})
+		got := resolver.Resolve(`now() - unixSeconds(o.timestamp)`, map[string]any{"timestamp": "2024-01-15T10:30:00Z"})
 		if len(got) != 1 {
 			t.Fatalf("expected 1 result, got %d", len(got))
 		}

--- a/pkg/resolver/starlark.go
+++ b/pkg/resolver/starlark.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kubernetes-sigs/resource-state-metrics/pkg/metricutil"
 	"github.com/kubernetes-sigs/resource-state-metrics/pkg/options"
+	startime "go.starlark.net/lib/time"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -127,8 +128,9 @@ func (sr *StarlarkResolver) resolveWithSteps(thread *starlark.Thread, obj map[st
 		"metric":            starlark.NewBuiltin("metric", metricBuiltin),
 		"family":            starlark.NewBuiltin("family", familyBuiltin),
 		"label_prefix":      starlark.NewBuiltin("label_prefix", labelPrefixBuiltin),
-		"timestamp":         starlark.NewBuiltin("timestamp", timestampBuiltin),
-		"parse_time":        starlark.NewBuiltin("parse_time", parseTimeBuiltin),
+		// time module provides time.now(), time.parse_time(s), durations, etc.
+		// See https://github.com/google/starlark-go/blob/master/lib/time/time.go.
+		"time": startime.Module,
 	}
 
 	objValue, err := goToStarlark(obj)
@@ -255,38 +257,6 @@ func labelPrefixBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	}
 
 	return result, nil
-}
-
-// timestampBuiltin returns the current time as Unix seconds (a float).
-// This enables computing durations, e.g., `timestamp() - parse_time(o.status.conditions[0].lastTransitionTime)`.
-func timestampBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	if err := starlark.UnpackArgs("timestamp", args, kwargs); err != nil {
-		return nil, err
-	}
-
-	return starlark.Float(float64(time.Now().Unix())), nil
-}
-
-// parseTimeBuiltin parses an RFC-3339 timestamp string and returns Unix seconds (a float).
-// Kubernetes condition `lastTransitionTime` fields are RFC-3339 strings.
-// An empty input returns 0.0 so callers can guard with `if ts_str:` without an error.
-// A malformed non-empty input returns a parse error.
-func parseTimeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var s string
-	if err := starlark.UnpackArgs("parse_time", args, kwargs, "s", &s); err != nil {
-		return nil, err
-	}
-
-	if s == "" {
-		return starlark.Float(0.0), nil
-	}
-
-	t, err := time.Parse(time.RFC3339Nano, s)
-	if err != nil {
-		return nil, fmt.Errorf("invalid RFC-3339 timestamp %q: %w", s, err)
-	}
-
-	return starlark.Float(float64(t.Unix())), nil
 }
 
 // goToStarlark converts a Go value to a Starlark value.

--- a/pkg/resolver/starlark.go
+++ b/pkg/resolver/starlark.go
@@ -127,6 +127,8 @@ func (sr *StarlarkResolver) resolveWithSteps(thread *starlark.Thread, obj map[st
 		"metric":            starlark.NewBuiltin("metric", metricBuiltin),
 		"family":            starlark.NewBuiltin("family", familyBuiltin),
 		"label_prefix":      starlark.NewBuiltin("label_prefix", labelPrefixBuiltin),
+		"timestamp":         starlark.NewBuiltin("timestamp", timestampBuiltin),
+		"parse_time":        starlark.NewBuiltin("parse_time", parseTimeBuiltin),
 	}
 
 	objValue, err := goToStarlark(obj)
@@ -253,6 +255,38 @@ func labelPrefixBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	}
 
 	return result, nil
+}
+
+// timestampBuiltin returns the current time as Unix seconds (a float).
+// This enables computing durations, e.g., `timestamp() - parse_time(o.status.conditions[0].lastTransitionTime)`.
+func timestampBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if err := starlark.UnpackArgs("timestamp", args, kwargs); err != nil {
+		return nil, err
+	}
+
+	return starlark.Float(float64(time.Now().Unix())), nil
+}
+
+// parseTimeBuiltin parses an RFC-3339 timestamp string and returns Unix seconds (a float).
+// Kubernetes condition `lastTransitionTime` fields are RFC-3339 strings.
+// An empty input returns 0.0 so callers can guard with `if ts_str:` without an error.
+// A malformed non-empty input returns a parse error.
+func parseTimeBuiltin(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var s string
+	if err := starlark.UnpackArgs("parse_time", args, kwargs, "s", &s); err != nil {
+		return nil, err
+	}
+
+	if s == "" {
+		return starlark.Float(0.0), nil
+	}
+
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid RFC-3339 timestamp %q: %w", s, err)
+	}
+
+	return starlark.Float(float64(t.Unix())), nil
 }
 
 // goToStarlark converts a Go value to a Starlark value.

--- a/pkg/resolver/starlark_test.go
+++ b/pkg/resolver/starlark_test.go
@@ -562,6 +562,262 @@ families = [family(name="test", help="test", kind="gauge", samples=[
 	}
 }
 
+func TestStarlarkResolver_Timestamp(t *testing.T) {
+	t.Parallel()
+
+	script := `
+now = timestamp()
+samples = [
+    metric(labels={"type": "current"}, value=now),
+]
+families = [
+    family(name="timestamp_metric", help="Current timestamp", kind="gauge", samples=samples)
+]
+`
+
+	obj := map[string]interface{}{}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	families, err := sg.Resolve(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(families) != 1 || len(families[0].Samples) != 1 {
+		t.Fatalf("expected 1 family with 1 sample")
+	}
+
+	ts := families[0].Samples[0].Value
+	// The timestamp should be a reasonable Unix epoch (after 2024-01-01)
+	if ts < 1704067200 {
+		t.Errorf("timestamp %f is too small (before 2024-01-01)", ts)
+	}
+}
+
+func TestStarlarkResolver_TimestampDuration(t *testing.T) {
+	t.Parallel()
+
+	// Compute duration: timestamp() - a known past time (2024-01-15T10:30:00Z = 1705314600)
+	script := `
+past_unix = 1705314600.0
+duration = timestamp() - past_unix
+samples = [
+    metric(labels={"kind": "test"}, value=duration),
+]
+families = [
+    family(name="duration_metric", help="Duration since event", kind="gauge", samples=samples)
+]
+`
+
+	obj := map[string]interface{}{}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	families, err := sg.Resolve(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(families) != 1 || len(families[0].Samples) != 1 {
+		t.Fatalf("expected 1 family with 1 sample")
+	}
+
+	duration := families[0].Samples[0].Value
+	// Duration since 2024-01-15 should be positive and large
+	if duration < 0 {
+		t.Errorf("expected positive duration, got %f", duration)
+	}
+}
+
+func TestStarlarkResolver_TimestampNoArgs(t *testing.T) {
+	t.Parallel()
+
+	// timestamp() should fail if called with arguments
+	script := `
+ts = timestamp("bad_arg")
+families = []
+`
+
+	obj := map[string]interface{}{}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	_, err := sg.Resolve(obj)
+	if err == nil {
+		t.Fatal("expected error when calling timestamp with arguments, got nil")
+	}
+}
+
+func TestStarlarkResolver_ParseTime(t *testing.T) {
+	t.Parallel()
+
+	// 2024-01-15T10:30:00Z = 1705314600 Unix seconds
+	script := `
+parsed = parse_time("2024-01-15T10:30:00Z")
+samples = [metric(labels={"kind": "test"}, value=parsed)]
+families = [family(name="parsed_metric", help="Parsed timestamp", kind="gauge", samples=samples)]
+`
+
+	obj := map[string]interface{}{}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	families, err := sg.Resolve(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := families[0].Samples[0].Value, 1705314600.0; got != want {
+		t.Errorf("parse_time returned %f, expected %f", got, want)
+	}
+}
+
+func TestStarlarkResolver_ParseTimeRFC3339Nano(t *testing.T) {
+	t.Parallel()
+
+	// Kubernetes lastTransitionTime is often RFC-3339 with sub-second precision.
+	// Sub-seconds are truncated when returning Unix seconds (1705314600).
+	script := `
+parsed = parse_time("2024-01-15T10:30:00.123456789Z")
+samples = [metric(labels={"kind": "test"}, value=parsed)]
+families = [family(name="parsed_metric", help="Parsed timestamp", kind="gauge", samples=samples)]
+`
+
+	obj := map[string]interface{}{}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	families, err := sg.Resolve(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := families[0].Samples[0].Value, 1705314600.0; got != want {
+		t.Errorf("parse_time returned %f, expected %f", got, want)
+	}
+}
+
+func TestStarlarkResolver_ParseTimeEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Empty string is a legitimate "not set" signal, returns 0.0 (no error).
+	script := `
+parsed = parse_time("")
+samples = [metric(labels={"kind": "test"}, value=parsed)]
+families = [family(name="parsed_metric", help="Parsed timestamp", kind="gauge", samples=samples)]
+`
+
+	obj := map[string]interface{}{}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	families, err := sg.Resolve(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := families[0].Samples[0].Value, 0.0; got != want {
+		t.Errorf("parse_time(\"\") returned %f, expected %f", got, want)
+	}
+}
+
+func TestStarlarkResolver_ParseTimeInvalid(t *testing.T) {
+	t.Parallel()
+
+	// Malformed non-empty input is a real error — fail loudly so script bugs surface.
+	script := `
+parsed = parse_time("not-a-timestamp")
+families = []
+`
+
+	obj := map[string]interface{}{}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	_, err := sg.Resolve(obj)
+	if err == nil {
+		t.Fatal("expected error when parsing malformed timestamp, got nil")
+	}
+}
+
+func TestStarlarkResolver_ParseTimeNoArgs(t *testing.T) {
+	t.Parallel()
+
+	script := `
+parsed = parse_time()
+families = []
+`
+
+	obj := map[string]interface{}{}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	_, err := sg.Resolve(obj)
+	if err == nil {
+		t.Fatal("expected error when calling parse_time without args, got nil")
+	}
+}
+
+// TestStarlarkResolver_ConditionAgeFilter exercises the production use case:
+// suppress a condition-derived metric until the condition has held its current
+// status for at least `grace` seconds.
+func TestStarlarkResolver_ConditionAgeFilter(t *testing.T) {
+	t.Parallel()
+
+	// past condition (well outside grace) -> emit; recent condition -> suppress.
+	script := `
+grace = 90.0
+samples = []
+for c in obj["status"]["conditions"]:
+    if c["type"] == "Synced" and c["status"] != "True":
+        age = timestamp() - parse_time(c.get("lastTransitionTime", ""))
+        if age < grace:
+            continue
+        samples.append(metric(labels={"reason": c["reason"]}, value=1.0))
+families = [family(name="not_synced", help="not synced", kind="gauge", samples=samples)]
+`
+
+	now := time.Now()
+	old := now.Add(-10 * time.Minute).UTC().Format(time.RFC3339Nano)
+	fresh := now.Add(-10 * time.Second).UTC().Format(time.RFC3339Nano)
+
+	makeObj := func(transitionTime string) map[string]interface{} {
+		return map[string]interface{}{
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":               "Synced",
+						"status":             "False",
+						"reason":             "ReconcileError",
+						"lastTransitionTime": transitionTime,
+					},
+				},
+			},
+		}
+	}
+
+	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
+
+	families, err := sg.Resolve(makeObj(old))
+	if err != nil {
+		t.Fatalf("unexpected error for old condition: %v", err)
+	}
+
+	if len(families[0].Samples) != 1 {
+		t.Errorf("expected 1 sample for condition older than grace, got %d", len(families[0].Samples))
+	}
+
+	families, err = sg.Resolve(makeObj(fresh))
+	if err != nil {
+		t.Fatalf("unexpected error for fresh condition: %v", err)
+	}
+
+	if len(families[0].Samples) != 0 {
+		t.Errorf("expected 0 samples for condition inside grace, got %d", len(families[0].Samples))
+	}
+}
+
 func TestStarlarkResolver_FileOptions_Set(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/resolver/starlark_test.go
+++ b/pkg/resolver/starlark_test.go
@@ -562,16 +562,16 @@ families = [family(name="test", help="test", kind="gauge", samples=[
 	}
 }
 
-func TestStarlarkResolver_Timestamp(t *testing.T) {
+func TestStarlarkResolver_TimeNow(t *testing.T) {
 	t.Parallel()
 
+	// time.now() returns a time.time; .unix gives Unix seconds as an int.
 	script := `
-now = timestamp()
 samples = [
-    metric(labels={"type": "current"}, value=now),
+    metric(labels={"type": "current"}, value=float(time.now().unix)),
 ]
 families = [
-    family(name="timestamp_metric", help="Current timestamp", kind="gauge", samples=samples)
+    family(name="now_metric", help="Current time", kind="gauge", samples=samples)
 ]
 `
 
@@ -579,29 +579,37 @@ families = [
 
 	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
 
+	// Capture a wall-clock window around Resolve() to assert closely.
+	before := time.Now().Unix()
+
 	families, err := sg.Resolve(obj)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
+	after := time.Now().Unix()
 
 	if len(families) != 1 || len(families[0].Samples) != 1 {
 		t.Fatalf("expected 1 family with 1 sample")
 	}
 
 	ts := families[0].Samples[0].Value
-	// The timestamp should be a reasonable Unix epoch (after 2024-01-01)
-	if ts < 1704067200 {
-		t.Errorf("timestamp %f is too small (before 2024-01-01)", ts)
+	// Allow a 5-second slop on either side to absorb scheduling jitter without
+	// pinning to an arbitrary calendar date that ages badly.
+	const delta = 5.0
+	if ts < float64(before)-delta || ts > float64(after)+delta {
+		t.Errorf("time.now().unix = %f, expected within [%d-%g, %d+%g]", ts, before, delta, after, delta)
 	}
 }
 
-func TestStarlarkResolver_TimestampDuration(t *testing.T) {
+func TestStarlarkResolver_TimeDuration(t *testing.T) {
 	t.Parallel()
 
-	// Compute duration: timestamp() - a known past time (2024-01-15T10:30:00Z = 1705314600)
+	// Compute duration in seconds: time.now() - parse_time("2024-01-15T10:30:00Z")
+	// yields a time.duration, whose .seconds attribute is a float.
 	script := `
-past_unix = 1705314600.0
-duration = timestamp() - past_unix
+past = time.parse_time("2024-01-15T10:30:00Z")
+duration = (time.now() - past).seconds
 samples = [
     metric(labels={"kind": "test"}, value=duration),
 ]
@@ -624,38 +632,20 @@ families = [
 	}
 
 	duration := families[0].Samples[0].Value
-	// Duration since 2024-01-15 should be positive and large
-	if duration < 0 {
+	// Duration since 2024-01-15 should be positive.
+	if duration <= 0 {
 		t.Errorf("expected positive duration, got %f", duration)
-	}
-}
-
-func TestStarlarkResolver_TimestampNoArgs(t *testing.T) {
-	t.Parallel()
-
-	// timestamp() should fail if called with arguments
-	script := `
-ts = timestamp("bad_arg")
-families = []
-`
-
-	obj := map[string]interface{}{}
-
-	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
-
-	_, err := sg.Resolve(obj)
-	if err == nil {
-		t.Fatal("expected error when calling timestamp with arguments, got nil")
 	}
 }
 
 func TestStarlarkResolver_ParseTime(t *testing.T) {
 	t.Parallel()
 
-	// 2024-01-15T10:30:00Z = 1705314600 Unix seconds
+	// 2024-01-15T10:30:00Z = 1705314600 Unix seconds. .unix returns an int;
+	// the test sample is a float so we cast at the script boundary.
 	script := `
-parsed = parse_time("2024-01-15T10:30:00Z")
-samples = [metric(labels={"kind": "test"}, value=parsed)]
+parsed = time.parse_time("2024-01-15T10:30:00Z")
+samples = [metric(labels={"kind": "test"}, value=float(parsed.unix))]
 families = [family(name="parsed_metric", help="Parsed timestamp", kind="gauge", samples=samples)]
 `
 
@@ -669,7 +659,7 @@ families = [family(name="parsed_metric", help="Parsed timestamp", kind="gauge", 
 	}
 
 	if got, want := families[0].Samples[0].Value, 1705314600.0; got != want {
-		t.Errorf("parse_time returned %f, expected %f", got, want)
+		t.Errorf("time.parse_time(...).unix returned %f, expected %f", got, want)
 	}
 }
 
@@ -677,10 +667,10 @@ func TestStarlarkResolver_ParseTimeRFC3339Nano(t *testing.T) {
 	t.Parallel()
 
 	// Kubernetes lastTransitionTime is often RFC-3339 with sub-second precision.
-	// Sub-seconds are truncated when returning Unix seconds (1705314600).
+	// Sub-seconds are truncated when reading .unix (1705314600).
 	script := `
-parsed = parse_time("2024-01-15T10:30:00.123456789Z")
-samples = [metric(labels={"kind": "test"}, value=parsed)]
+parsed = time.parse_time("2024-01-15T10:30:00.123456789Z")
+samples = [metric(labels={"kind": "test"}, value=float(parsed.unix))]
 families = [family(name="parsed_metric", help="Parsed timestamp", kind="gauge", samples=samples)]
 `
 
@@ -694,31 +684,7 @@ families = [family(name="parsed_metric", help="Parsed timestamp", kind="gauge", 
 	}
 
 	if got, want := families[0].Samples[0].Value, 1705314600.0; got != want {
-		t.Errorf("parse_time returned %f, expected %f", got, want)
-	}
-}
-
-func TestStarlarkResolver_ParseTimeEmpty(t *testing.T) {
-	t.Parallel()
-
-	// Empty string is a legitimate "not set" signal, returns 0.0 (no error).
-	script := `
-parsed = parse_time("")
-samples = [metric(labels={"kind": "test"}, value=parsed)]
-families = [family(name="parsed_metric", help="Parsed timestamp", kind="gauge", samples=samples)]
-`
-
-	obj := map[string]interface{}{}
-
-	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
-
-	families, err := sg.Resolve(obj)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if got, want := families[0].Samples[0].Value, 0.0; got != want {
-		t.Errorf("parse_time(\"\") returned %f, expected %f", got, want)
+		t.Errorf("time.parse_time(...).unix returned %f, expected %f", got, want)
 	}
 }
 
@@ -727,7 +693,7 @@ func TestStarlarkResolver_ParseTimeInvalid(t *testing.T) {
 
 	// Malformed non-empty input is a real error — fail loudly so script bugs surface.
 	script := `
-parsed = parse_time("not-a-timestamp")
+parsed = time.parse_time("not-a-timestamp")
 families = []
 `
 
@@ -741,24 +707,6 @@ families = []
 	}
 }
 
-func TestStarlarkResolver_ParseTimeNoArgs(t *testing.T) {
-	t.Parallel()
-
-	script := `
-parsed = parse_time()
-families = []
-`
-
-	obj := map[string]interface{}{}
-
-	sg := NewStarlarkResolver(klog.NewKlogr(), script, 5*time.Second, 100000)
-
-	_, err := sg.Resolve(obj)
-	if err == nil {
-		t.Fatal("expected error when calling parse_time without args, got nil")
-	}
-}
-
 // TestStarlarkResolver_ConditionAgeFilter exercises the production use case:
 // suppress a condition-derived metric until the condition has held its current
 // status for at least `grace` seconds.
@@ -766,12 +714,17 @@ func TestStarlarkResolver_ConditionAgeFilter(t *testing.T) {
 	t.Parallel()
 
 	// past condition (well outside grace) -> emit; recent condition -> suppress.
+	// time.parse_time errors on empty input, so guard before calling it — the
+	// "no lastTransitionTime" case is "we don't know the age, skip the gate".
 	script := `
 grace = 90.0
 samples = []
 for c in obj["status"]["conditions"]:
     if c["type"] == "Synced" and c["status"] != "True":
-        age = timestamp() - parse_time(c.get("lastTransitionTime", ""))
+        ts = c.get("lastTransitionTime", "")
+        if not ts:
+            continue
+        age = (time.now() - time.parse_time(ts)).seconds
         if age < grace:
             continue
         samples.append(metric(labels={"reason": c["reason"]}, value=1.0))


### PR DESCRIPTION
## Summary

Extend both the CEL and Starlark resolvers so metric expressions can compute durations from Kubernetes timestamps (e.g. "how long has this condition held its current status").

- **CEL:** register a zero-arg `now()` that returns current Unix epoch seconds as a double. Paired with the existing `unixSeconds(s)` helper to parse RFC-3339 timestamp strings. Named `now()` rather than `timestamp()` so it does not shadow CEL's built-in `timestamp(string)` cast.
- **Starlark:** enable the upstream `go.starlark.net/lib/time` module under the name `time`. Scripts use `time.now()` for the current time and `time.parse_time(s)` to parse RFC-3339 / RFC-3339Nano strings; subtracting two `time.time` values yields a `time.duration` whose `.seconds` attribute is a float. Empty input to `time.parse_time` errors — guard with `if not ts: continue` to treat "field not set" as "skip the gate".

Primary use case: report how long a resource has held its current condition status, so operators can find resources stuck in a bad state rather than learning only that some count of resources is currently unhealthy. Example — a `not_synced_age_seconds` gauge that fires when a Kubernetes Composite Resource has been `Synced=False` for over 30 minutes:

    for c in obj["status"]["conditions"]:
        if c["type"] == "Synced" and c["status"] != "True":
            ts = c.get("lastTransitionTime", "")
            if not ts:
                continue
            age = (time.now() - time.parse_time(ts)).seconds
            samples.append(metric(
                labels={"reason": c["reason"]},
                value=age,
            ))

A monitor on `max(not_synced_age_seconds) > 1800` then identifies the long-standing unsynced resources directly, instead of inferring them from a flat not_synced count that conflates "many resources transiently churning" with "one resource stuck for hours". The same primitive also lets a script grace-window transient flips during operator-driven churn (e.g. Crossplane package upgrades that briefly flip many XRs to ReconcileError before retrying).

The CEL equivalent uses the existing `unixSeconds(...)` helper:

    now() - unixSeconds(o.status.conditions[0].lastTransitionTime)

Changes:

- CEL: register `now` as a zero-arg `DoubleType` function with cost budget 1 (just reads the system clock).
- Starlark: expose `go.starlark.net/lib/time` as the `time` module, giving scripts `time.now()`, `time.parse_time(s)`, durations, etc.
- Tests for both resolvers covering current-time reads (with a clock-skew-tolerant window), duration computation, parse error handling, and an end-to-end condition-age pattern.
- Dockerfile: cross-compile via `GOOS`/`GOARCH` instead of running the Go toolchain under QEMU; default `BUILDPLATFORM`/`TARGETOS`/`TARGETARCH` so non-BuildKit builds still work; `make -B` to force a rebuild and ignore any stale binary in the build context.

<!-- Fixes # -->

## Checklist

- [x] `make verify` passes
- [x] Documentation updated (if applicable)
- [x] Tests added or updated (if applicable)