### PR TITLE
chore: Drop `vendor` entry from ignore-list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Module paraphernalia
 assets/
 /resource-state-metrics
-vendor/
 
 # Generated intermediaries
 tests/golden/metrics.txt


### PR DESCRIPTION

## Summary
This is redundant because we don't vendor anyway, but ignoring gets in the way of downstream hermetic cases where vendoring is required.

<!-- Describe the changes this patch introduces, in as much detail as possible. -->

<!-- Does this patch address a corresponding issue? If so please uncomment the line below and specify the issue number. -->

<!-- Fixes # -->

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)
