### PR TITLE
ci: Setup main and tag postsubmits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 SHELL := /bin/bash
 
+ALL_ARCH ?= amd64 arm64
+# A literal comma cannot appear in a $(subst) call because Make parses it as
+# an argument separator before the function ever sees it.
+comma := ,
+DOCKER_BUILDX_CMD ?= docker buildx
 GOBIN ?= $(shell go env GOBIN)
 ifeq ($(GOBIN),)
 GOBIN = $(shell go env GOPATH)/bin
@@ -41,6 +46,8 @@ PIPX ?= pipx
 PPROF_OPTIONS ?=
 PPROF_PORT ?= 9998
 PROJECT_NAME = resource-state-metrics
+REGISTRY ?= us-central1-docker.pkg.dev/k8s-staging-images/resource-state-metrics
+TAG ?= $(BUILD_TAG)
 V ?= 4
 VALE ?= vale
 VALE_ARCH ?= $(if $(filter $(shell uname -m),arm64),macOS_arm64,Linux_64-bit)
@@ -166,6 +173,12 @@ $(PROJECT_NAME): $(GO_FILES)
 
 .PHONY: build
 build: $(PROJECT_NAME)
+
+.PHONY: image-push
+image-push:
+	$(DOCKER_BUILDX_CMD) build --pull --push \
+		--platform $(subst $(eval ) ,$(comma),$(addprefix linux/,$(ALL_ARCH))) \
+		-t $(REGISTRY)/$(PROJECT_NAME):$(TAG) .
 
 ###########
 # Running #

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,28 @@
+# Copyright 2026 The Kubernetes resource-state-metrics Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 2700s
+# ALLOW_LOOSE lets Cloud Build define substitution variables (e.g., _GIT_TAG)
+# without failing when this config doesn't reference all of them.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2'
+    entrypoint: make
+    env:
+      - DOCKER_BUILDX_CMD=/buildx-entrypoint
+      - TAG=$_PULL_BASE_REF
+    args:
+      - image-push


### PR DESCRIPTION
## Summary
Introduce cloudbuild.yaml and `image-push` target to help setup
postsubmit jobs per main and tag push. See [1] for more.

[1]: https://github.com/kubernetes/test-infra/pull/37163
<!-- Describe the changes this patch introduces, in as much detail as possible. -->

<!-- Does this patch address a corresponding issue? If so please uncomment the line below and specify the issue number. -->

<!-- Fixes # -->

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)
