### PR TITLE
chore(ci): detect go version from go.mod

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -20,8 +20,6 @@ on:
   pull_request:
     branches:
       - main
-env:
-  GO_VERSION: 1.25
 jobs:
   vet:
     runs-on: ubuntu-latest
@@ -31,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Vet the codebase
         run: go vet ./...
   verify_generated:
@@ -43,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Setup dependencies
         run: make setup
       - name: Verify generated assets
@@ -59,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Setup dependencies
         run: make setup
       - name: Run linter
@@ -87,7 +85,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Setup dependencies
         run: make setup
       - name: Run unit tests
@@ -101,7 +99,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Setup dependencies
         run: make setup
       - name: Run e2e tests
@@ -115,7 +113,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Setup dependencies
         run: make setup
       - name: Create kind cluster


### PR DESCRIPTION
## Summary

align the validation step (.github.workflows/validation.yaml) to the release step (.github/workflows/release.yaml) and use the go-version-file directive of actions/setup-go to detect the needed go version

<!-- Fixes # -->

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)
