### PR TITLE
fix: distinguish empty from failed metric value resolution

### DIFF
--- a/internal/family.go
+++ b/internal/family.go
@@ -17,6 +17,7 @@ limitations under the License.
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"regexp"
@@ -184,9 +185,15 @@ func (f *FamilyType) buildMetricString(unstructured *unstructured.Unstructured) 
 
 		resolvedLabelKeys, resolvedLabelValues, resolvedExpandedLabelSet := resolveLabels(metricLabels, resolverInstance, unstructured.Object)
 
-		resolvedValue, ok := resolveMetricValue(resolverInstance, metric.Value, unstructured.Object, resolvedExpandedLabelSet)
+		resolvedValue, ok, err := resolveMetricValue(resolverInstance, metric.Value, unstructured.Object, resolvedExpandedLabelSet)
+		if err != nil {
+			logger.V(1).Error(fmt.Errorf("error resolving metric value %q: %w", metric.Value, err), "skipping")
+			putBuilder(metricRawBuilder)
+
+			continue
+		}
+
 		if !ok {
-			logger.V(1).Error(fmt.Errorf("error resolving metric value %q", metric.Value), "skipping")
 			putBuilder(metricRawBuilder)
 
 			continue
@@ -276,22 +283,33 @@ func inheritMetricLabels(f *FamilyType, metric *v1alpha1.Metric) []v1alpha1.Labe
 // resolver returns a scalar, it is returned directly. If the resolver returns
 // a list (indexed keys like "fieldParent#N"), the values are collected in
 // order and stored in resolvedExpandedLabelSet under the sentinel key so that
-// writeMetricSamples can emit one sample per element.
-func resolveMetricValue(resolverInstance resolver.Resolver, valueExpr string, obj map[string]any, resolvedExpandedLabelSet map[string][]string) (string, bool) {
+// writeMetricSamples can emit one sample per element. Returns (value, ok, error):
+//   - ("value", true, nil): scalar or expanded list — emit metric(s)
+//   - ("", false, nil): empty result (e.g. guarded CEL expression) — skip silently
+//   - ("", false, err): resolution failed — caller should log
+func resolveMetricValue(resolverInstance resolver.Resolver, valueExpr string, obj map[string]any, resolvedExpandedLabelSet map[string][]string) (string, bool, error) {
 	resolvedValueMap := resolverInstance.Resolve(valueExpr, obj)
+
+	// An empty map means the expression evaluated successfully but
+	// produced no results (e.g. an empty list from a guarded CEL
+	// expression). This is not an error — silently emit zero samples.
+	if len(resolvedValueMap) == 0 {
+		return "", false, nil
+	}
+
 	if resolvedValue, found := resolvedValueMap[valueExpr]; found {
-		return resolvedValue, true
+		return resolvedValue, true, nil
 	}
 
 	expandedValues := collectIndexedResolvedValues(resolvedValueMap)
 
 	if len(expandedValues) == 0 {
-		return "", false
+		return "", false, errors.New("resolver returned non-empty map but no scalar or expanded values matched")
 	}
 
 	resolvedExpandedLabelSet[expandedValueSentinel] = expandedValues
 
-	return "", true
+	return "", true, nil
 }
 
 // resolveLabels resolves label keys and values including handling of composite map/list structures.

--- a/internal/family_test.go
+++ b/internal/family_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/kubernetes-sigs/resource-state-metrics/pkg/apis/resourcestatemetrics/v1alpha1"
+	"github.com/kubernetes-sigs/resource-state-metrics/pkg/resolver"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 )
@@ -336,6 +337,82 @@ func Test_collectIndexedResolvedValues(t *testing.T) {
 
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("collectIndexedResolvedValues() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type fakeResolver struct {
+	result map[string]string
+}
+
+func (f fakeResolver) Resolve(_ string, _ map[string]interface{}) map[string]string {
+	return f.result
+}
+
+func TestResolveMetricValue(t *testing.T) {
+	t.Parallel()
+
+	valueExpr := "value-expression"
+
+	type want struct {
+		value    string
+		ok       bool
+		err      bool
+		expanded []string
+	}
+
+	tests := []struct {
+		name     string
+		resolved map[string]string
+		want     want
+	}{
+		{
+			name:     "empty map skips silently without error",
+			resolved: map[string]string{},
+			want:     want{value: "", ok: false, err: false},
+		},
+		{
+			name:     "scalar match returns the value",
+			resolved: map[string]string{valueExpr: "3"},
+			want:     want{value: "3", ok: true, err: false},
+		},
+		{
+			name:     "expanded list is carried under the sentinel",
+			resolved: map[string]string{"conditions#0": "1", "conditions#1": "0"},
+			want:     want{value: "", ok: true, err: false, expanded: []string{"1", "0"}},
+		},
+		{
+			name:     "non-empty map with no scalar or expanded match errors",
+			resolved: map[string]string{"app": "foo"},
+			want:     want{value: "", ok: false, err: true},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var resolverInstance resolver.Resolver = fakeResolver{result: testCase.resolved}
+
+			expanded := map[string][]string{}
+
+			value, ok, err := resolveMetricValue(resolverInstance, valueExpr, nil, expanded)
+
+			if value != testCase.want.value {
+				t.Errorf("value = %q, want %q", value, testCase.want.value)
+			}
+
+			if ok != testCase.want.ok {
+				t.Errorf("ok = %v, want %v", ok, testCase.want.ok)
+			}
+
+			if gotErr := err != nil; gotErr != testCase.want.err {
+				t.Errorf("err = %v, want error: %v", err, testCase.want.err)
+			}
+
+			if diff := cmp.Diff(testCase.want.expanded, expanded[expandedValueSentinel]); diff != "" {
+				t.Errorf("expanded values mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

When using wildcards for getting multiple resource with different groups and kinds, resources that get caught without certain fields (for example `status.conditions`) can be guarded with `has()`  (for example `has(o.status) && has(o.status.conditions) ? o.status.conditions.map(c, c.type) : []`) CEL expressions to return an empty list []. The CEL resolver correctly evaluates these to an empty map, but `resolveMetricValue` treats all non-scalar results the same by logging a noisy error for every resource that legitimately has no data for a given metric family.

Resolving metrics value through `resolveMetricValue` now returns `(string, bool, error)`, letting callers distinguish three outcomes: a successfully resolved value, an empty result that should be silently skipped, and an actual resolution failure that should be logged.

<!-- Describe the changes this patch introduces, in as much detail as possible. -->

<!-- Does this patch address a corresponding issue? If so please uncomment the line below and specify the issue number. -->

<!-- Fixes # -->

## How to reproduce

Apply a ResourceMonitor with CEL guards to a running cluster with RSM
```yaml
apiVersion: resource-state-metrics.instrumentation.k8s-sigs.io/v1alpha1
kind: ResourceMetricsMonitor
metadata:
  name: repro-empty-guard
  namespace: default
spec:
  configuration:
    stores:
      - group: ""
        version: "v1"
        kind: "*"
        resource: "*"
        resolver: "cel"
        families:
          - name: "resource_condition"
            help: "Resource condition status (1=True, 0=False)"
            metrics:
              - labels:
                  - name: "condition_type"
                    value: 'has(o.status) && has(o.status.conditions) ? o.status.conditions.map(c, c.type) : []'
                value: 'has(o.status) && has(o.status.conditions) ? o.status.conditions.map(c, c.status == "True" ? 1 : 0) : []'
```

We can observe in the RSM logs such messages when evaluating resources without conditions

```bash
E0706 16:28:30.897560   78995 family.go:188] "skipping" err="error resolving metric value \"has(o.status) && has(o.status.conditions) ? o.status.conditions.map(c, c.status == \\\"True\\\" ? 1 : 0) : []\"" family="resource_condition"
```

Also we can see that the resolving is working for resources with conditions:
```bash
kube_customresource_resource_condition{condition_type="Ready",kind="Node",name="rsm-repro-control-plane",...} 1.000000
kube_customresource_resource_condition{condition_type="Initialized",kind="Pod",name="coredns-...",namespace="kube-system"} 1.000000
```

## Checklist

- [x] `make verify` passes
- ~[ ] Documentation updated (if applicable)~
- [x] Tests added or updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how metric values are resolved when expressions don’t match expected values.
  * Prevented silent failures by logging mismatched cases more clearly, while still skipping empty results quietly.
* **Tests**
  * Added coverage for empty, matched, expanded, and non-matching metric resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->