### PR TITLE
ci: Comment on LGTM-based workflows

### DIFF
--- a/.github/workflows/flake-detection.yaml
+++ b/.github/workflows/flake-detection.yaml
@@ -29,6 +29,23 @@ on:
       - main
 jobs:
   tests:
+    # Match only the event that adds the lgtm label. The workflow fires
+    # on every "labeled" event, so adding other labels (approved, size/XL)
+    # produces a "skipped" status here. This is intentional:
+    #
+    # - contains(..labels.*.name, 'lgtm') would re-run the full 10-iteration
+    #   flake suite on every subsequent label addition — wasteful CI time
+    #   for no benefit when flake detection already passed.
+    # - Filtering by label name at the trigger level is not supported by
+    #   GitHub Actions for pull_request_target events.
+    # - Moving the condition to step-level is not possible because the job
+    #   calls a reusable workflow via "uses:", which only works at job level.
+    #
+    # The "skipped" status is harmless because flake-detection is not a
+    # required status check in branch protection rules. To avoid a spurious
+    # "skipped" overwriting a prior success, reviewers should comment /lgtm
+    # last — not grouped with /approve, since whichever label lands second
+    # would re-trigger this workflow with a non-matching event.
     if: github.event.label.name == 'lgtm'
     uses: ./.github/workflows/tests.yaml
     with:


### PR DESCRIPTION

## Summary
Due to current limitations, maintainers are requested to not use /approve and /lgtm in the same comment, but in consecutive ones, in that order.

<!-- Describe the changes this patch introduces, in as much detail as possible. -->

<!-- Does this patch address a corresponding issue? If so please uncomment the line below and specify the issue number. -->

<!-- Fixes # -->

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)
