### PR TITLE
ci: Drop flake detection runs to 3 

### DIFF
--- a/.github/workflows/flake-detection.yaml
+++ b/.github/workflows/flake-detection.yaml
@@ -49,5 +49,5 @@ jobs:
     if: github.event.label.name == 'lgtm'
     uses: ./.github/workflows/tests.yaml
     with:
-      iterations: 10
+      iterations: 3
       ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION


## Summary
I'm not sure how many workflow minutes CNCF gives us, but 10 feels like an overkill still. Three should be enough since the PR will have atleast one more check and that's also the number of runs used in OpenShift to catch flakes (some may still go undetected though, but that's the tradeoff we're making here).
<!-- Describe the changes this patch introduces, in as much detail as possible. -->

<!-- Does this patch address a corresponding issue? If so please uncomment the line below and specify the issue number. -->

<!-- Fixes # -->

## Checklist

- [ ] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)
