### PR TITLE
fix: Skip non-listable resources when expanding wildcard stores

### DIFF
--- a/internal/discovery.go
+++ b/internal/discovery.go
@@ -115,6 +115,22 @@ func (d *discoveryClient) ExpandWildcards(store *v1alpha1.Store) ([]v1alpha1.Sto
 			expanded.Kind = apiResource.Kind
 			expanded.Resource = apiResource.Name
 
+			// Informers require list+watch. Skip wildcard-matched resources
+			// that lack them (e.g. create-only TokenReview and the
+			// authorization.k8s.io review resources, whose REST storage
+			// supports only create; see k8s.io/kubernetes
+			// pkg/registry/{authentication,authorization}/rest) to avoid
+			// reflectors that fail with "the server does not allow this
+			// method". Explicitly named resources and those with no reported
+			// verbs are not filtered.
+			if wildcardMatchedResource(store) && len(apiResource.Verbs) > 0 && !supportsListWatch(apiResource.Verbs) {
+				d.logger.V(2).Info("Skipping wildcard-matched resource that does not support list+watch",
+					"resource", formatStorePattern(&expanded),
+					"verbs", apiResource.Verbs)
+
+				continue
+			}
+
 			d.logger.V(2).Info("Expanded wildcard store",
 				"pattern", formatStorePattern(store),
 				"expanded", formatStorePattern(&expanded))
@@ -132,6 +148,28 @@ func (d *discoveryClient) ExpandWildcards(store *v1alpha1.Store) ([]v1alpha1.Sto
 	}
 
 	return expandedStores, nil
+}
+
+// wildcardMatchedResource reports whether the store matches resources via a
+// wildcard Kind or Resource pattern rather than naming one exactly.
+func wildcardMatchedResource(store *v1alpha1.Store) bool {
+	return IsWildcard(store.Kind) || IsWildcard(store.Resource)
+}
+
+// supportsListWatch reports whether the verbs include both list and watch.
+func supportsListWatch(verbs []string) bool {
+	var hasList, hasWatch bool
+
+	for _, v := range verbs {
+		switch v {
+		case "list":
+			hasList = true
+		case "watch":
+			hasWatch = true
+		}
+	}
+
+	return hasList && hasWatch
 }
 
 // matchesPattern checks if a value matches a glob-style pattern.

--- a/internal/discovery_test.go
+++ b/internal/discovery_test.go
@@ -195,6 +195,22 @@ func TestExpandWildcards(t *testing.T) {
 				{Name: "cronjobs", Kind: "CronJob", Namespaced: true},
 			},
 		},
+		{
+			// Create-only: not listable/watchable.
+			GroupVersion: "authentication.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "tokenreviews", Kind: "TokenReview", Namespaced: false, Verbs: []string{"create"}},
+			},
+		},
+		{
+			GroupVersion: "authorization.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "subjectaccessreviews", Kind: "SubjectAccessReview", Namespaced: false, Verbs: []string{"create"}},
+				{Name: "selfsubjectaccessreviews", Kind: "SelfSubjectAccessReview", Namespaced: false, Verbs: []string{"create"}},
+				{Name: "localsubjectaccessreviews", Kind: "LocalSubjectAccessReview", Namespaced: true, Verbs: []string{"create"}},
+				{Name: "selfsubjectrulesreviews", Kind: "SelfSubjectRulesReview", Namespaced: false, Verbs: []string{"create"}},
+			},
+		},
 	}
 
 	discovery := NewResourceDiscovery(fakeDiscovery, logger)
@@ -257,6 +273,46 @@ func TestExpandWildcards(t *testing.T) {
 				Resource: "*",
 			},
 			expectedCount: 1, // ReplicaSet
+		},
+		{
+			name: "wildcard sweep skips create-only resource in one group",
+			store: &v1alpha1.Store{
+				Group:    "authentication.k8s.io",
+				Version:  "v1",
+				Kind:     "*",
+				Resource: "*",
+			},
+			expectedCount: 0, // tokenreviews is create-only, not list+watch
+		},
+		{
+			name: "wildcard sweep skips all create-only resources in a group",
+			store: &v1alpha1.Store{
+				Group:    "authorization.k8s.io",
+				Version:  "v1",
+				Kind:     "*",
+				Resource: "*",
+			},
+			expectedCount: 0, // all authorization.k8s.io review resources are create-only
+		},
+		{
+			name: "explicitly named create-only resource is honoured",
+			store: &v1alpha1.Store{
+				Group:    "*", // wildcard group, but Kind/Resource named exactly
+				Version:  "v1",
+				Kind:     "TokenReview",
+				Resource: "tokenreviews",
+			},
+			expectedCount: 1, // named explicitly, not verb-filtered
+		},
+		{
+			name: "empty verbs are treated as unknown and not filtered",
+			store: &v1alpha1.Store{
+				Group:    "apps",
+				Version:  "v1",
+				Kind:     "*",
+				Resource: "*",
+			},
+			expectedCount: 3, // apps resources carry no Verbs in fixtures; still expand
 		},
 		{
 			name: "no wildcards returns store unchanged",


### PR DESCRIPTION
## Summary

When specifying wildcard stores, for example using the manifest below, a bunch of logs are written indicating that the reflector couldn't perform the expected action (examples shown below). I personally mostly saw this with TokenReview, and SubjectAccessReview resources. NOTE: I have not noticed any instability introduced through the current behavior, simply log spam, so far.

Broad example manifest:

```yaml
apiVersion: resource-state-metrics.instrumentation.k8s-sigs.io/v1alpha1
kind: ResourceMetricsMonitor
metadata:
  name: reproduce-nonlistable
  namespace: default
spec:
  configuration:
    stores:
      - group: "*"
        version: "*"
        kind: "*"
        resource: "*"
        resolver: cel
        families:
          - name: "resource_condition"
            help: "Resource condition status (1=True, 0=False)"
            metrics:
              - resolver: cel
                labels:
                  - name: "condition_type"
                    value: "o.status.conditions.map(c, c.type)"
                value: "o.status.conditions.map(c, c.status == 'True' ? 1 : 0)"
```

Narrow example config:

```yaml
   stores:
      - group: "authentication.k8s.io"   # contains only create-only resources
        version: "*"
        kind: "*"
        resource: "*"
        resolver: cel
        families:
          - name: "resource_condition"
            help: "condition"
            metrics:
              - resolver: cel
                labels: []
                value: "1"
```

Example sample logs:
```
W0715 21:56:46.663109       1 reflector.go:569] `authorization.k8s.io/v1, Resource=selfsubjectaccessreviews` reflector: failed to list authorization.k8s.io/v1, Kind=SelfSubjectAccessReview: error listing authorization.k8s.io/v1, Resource=selfsubjectaccessreviews with options {{ }   false false   <nil> 0  <nil>}: the server does not allow this method on the requested resource
E0715 21:56:46.663750       1 reflector.go:166] "Unhandled Error" err="`authorization.k8s.io/v1, Resource=selfsubjectaccessreviews` reflector: Failed to watch authorization.k8s.io/v1, Kind=SelfSubjectAccessReview: failed to list authorization.k8s.io/v1, Kind=SelfSubjectAccessReview: error listing authorization.k8s.io/v1, Resource=selfsubjectaccessreviews with options {{ }   false false   <nil> 0  <nil>}: the server does not allow this method on the requested resource" logger="UnhandledError"
W0715 21:56:59.188403       1 reflector.go:569] `/v1, Resource=bindings` reflector: failed to list /v1, Kind=Binding: error listing /v1, Resource=bindings with options {{ }   false false   <nil> 0  <nil>}: the server could not find the requested resource
E0715 21:56:59.188883       1 reflector.go:166] "Unhandled Error" err="`/v1, Resource=bindings` reflector: Failed to watch /v1, Kind=Binding: failed to list /v1, Kind=Binding: error listing /v1, Resource=bindings with options {{ }   false false   <nil> 0  <nil>}: the server could not find the requested resource" logger="UnhandledError"
W0715 21:57:01.197428       1 reflector.go:569] `authentication.k8s.io/v1, Resource=tokenreviews` reflector: failed to list authentication.k8s.io/v1, Kind=TokenReview: error listing authentication.k8s.io/v1, Resource=tokenreviews with options {{ }   false false   <nil> 0  <nil>}: the server does not allow this method on the requested resource
E0715 21:57:01.198163       1 reflector.go:166] "Unhandled Error" err="`authentication.k8s.io/v1, Resource=tokenreviews` reflector: Failed to watch authentication.k8s.io/v1, Kind=TokenReview: failed to list authentication.k8s.io/v1, Kind=TokenReview: error listing authentication.k8s.io/v1, Resource=tokenreviews with options {{ }   false false   <nil> 0  <nil>}: the server does not allow this method on the requested resource" logger="UnhandledError"
W0715 21:57:05.295218       1 reflector.go:569] `authorization.k8s.io/v1, Resource=selfsubjectrulesreviews` reflector: failed to list authorization.k8s.io/v1, Kind=SelfSubjectRulesReview: error listing authorization.k8s.io/v1, Resource=selfsubjectrulesreviews with options {{ }   false false   <nil> 0  <nil>}: the server does not allow this method on the requested resource
```

<!-- Fixes # -->

This changeset addresses the above by skipping resources whose verbs don't include `List` and `Watch`

## Checklist

- [X] `make verify` passes
- [ ] Documentation updated (if applicable)
- [X] Tests added or updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wildcard resource expansion now skips create-only Kubernetes resources that cannot be listed or watched.
  * Explicitly named create-only resources continue to expand correctly.
  * Resources with unavailable verb information retain their previous expansion behavior.
* **Tests**
  * Added coverage for wildcard and explicit resource expansion across authentication and authorization APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->