### PR TITLE
build: Introduce `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+# Copyright 2026 The Kubernetes resource-state-metrics Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 7 # Increment this when adding to the allow list below.
+    assignees:
+      - "rexagod"
+    allow:
+      - dependency-name: "toolchain"
+      - dependency-name: "golang.org/x/*"
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/*"
+      - dependency-name: "github.com/prometheus/*"
+      - dependency-name: "github.com/google/cel-go"
+      - dependency-name: "go.starlark.net"
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      k8s:
+        patterns:
+          - "k8s.io/*"
+      k8s-sigs:
+        patterns:
+          - "sigs.k8s.io/*"
+      prometheus:
+        patterns:
+          - "github.com/prometheus/*"
+      cel:
+        patterns:
+          - "github.com/google/cel-go"
+      starlark:
+        patterns:
+          - "go.starlark.net"


### PR DESCRIPTION


## Summary
Allows for weekly one-PR-per-group-based dependabot updates. The groups reflect modules we rely on closely (K8s, Prometheus, resolver upstreams, etc.) and qualify as fairly trustable within the ecosystem. The only non-group is the toolchain update, made to facilitate toolchain updates from #47. The go version, as well as all other third-party bumps should be done at release time.

Downstream, especially enterprise consumers are advised to use the `GOTOOLCHAIN=local` variable to ignore the `gotoolchain` version and fallback to the go version found in the build environment, in the case a `gotoolchain` update request did not make it in time upstream.

Additionally, please ensure any pull requests directed towards bumping dependencies to patch CVEs is first validated by `govulncheck` that code symbols used within the codebase were affected directly, excluding the tests and other non-production peripherals. Bumps for these do not qualify as urgent and will be done when cutting a release.
<!-- Describe the changes this patch introduces, in as much detail as possible. -->

<!-- Does this patch address a corresponding issue? If so please uncomment the line below and specify the issue number. -->

<!-- Fixes # -->

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated weekly maintenance for approved project components.
  * Updates will be consolidated into grouped review requests to streamline maintenance and reduce disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->