### PR TITLE
ci(agentic): Drop `coderabbit` for `copilot`

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,31 @@
+# Disable CodeRabbit entirely.
+# The app cannot be removed from this repository, so this config
+# turns off every feature surface it exposes.
+
+reviews:
+  auto_review:
+    enabled: false
+  high_level_summary: false
+  review_status: false
+  commit_status: false
+  suggested_labels: false
+  suggested_reviewers: false
+  sequence_diagrams: false
+  related_issues: false
+  related_prs: false
+  assess_linked_issues: false
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+    autofix:
+      enabled: false
+
+chat:
+  auto_reply: false
+
+knowledge_base:
+  opt_out: true


### PR DESCRIPTION
## Summary

PTAL at the [Kubernetes Slack thread](https://kubernetes.slack.com/archives/C01672LSZL0/p1784188710239059?thread_ts=1780387166.316109&cid=C01672LSZL0) and https://github.com/kubernetes-sigs/resource-state-metrics/pull/46#issuecomment-4985767980.
<!-- Describe the changes this patch introduces, in as much detail as possible. -->

<!-- Does this patch address a corresponding issue? If so please uncomment the line below and specify the issue number. -->

<!-- Fixes # -->

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automated code review features, including summaries, status updates, suggestions, diagrams, and related issue assessments.
  * Disabled automated chat responses and knowledge base participation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->