### PR TITLE
ci(agentic): Drop `coderabbit` for `copilot`

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes resource-state-metrics Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
 # Disable CodeRabbit entirely.
 # The app cannot be removed from this repository, so this config
 # turns off every feature surface it exposes.


### PR DESCRIPTION
## Summary

https://github.com/kubernetes-sigs/resource-state-metrics/pull/54 continued (adds boilerplate header).

<!-- Describe the changes this patch introduces, in as much detail as possible. -->

<!-- Does this patch address a corresponding issue? If so please uncomment the line below and specify the issue number. -->

<!-- Fixes # -->

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)
