### PR TITLE
build: Pin KSM to v2.15.0 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -198,6 +198,9 @@ linters:
               desc: Use 'errors' or 'fmt' instead.
             - pkg: golang.org/x/exp/slices
               desc: Use 'slices' instead.
+    gomoddirectives:
+      replace-allow-list:
+        - k8s.io/kube-state-metrics/v2
     funlen:
       lines: 80
       statements: 60

--- a/go.mod
+++ b/go.mod
@@ -78,3 +78,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 )
+
+replace k8s.io/kube-state-metrics/v2 => k8s.io/kube-state-metrics/v2 v2.15.0 // Pin


### PR DESCRIPTION
## Summary
This was the last version that shipped with the API support we need for
/external endpoints, after which it went through a breaking change.
Might revisit later and try to wire this up to use the newer versions,
if they still support doing so (KSM doesn't explicitly offer library
 support). However, to the best of my knowledge, folks don't seem to use
this much or at all, which is a good thing as that indicates that the
resolver set is living up to the goal it was implemented for. This
endpoint is, at the end of the day, a fail-safe.
<!-- Describe the changes this patch introduces, in as much detail as possible. -->

<!-- Does this patch address a corresponding issue? If so please uncomment the line below and specify the issue number. -->

<!-- Fixes # -->

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)
