### PR TITLE
Drop automaxprocs for go-1.25+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.70.0
 	go.starlark.net v0.0.0-20260210143700-b62fd896b91b
-	go.uber.org/automaxprocs v1.5.3
 	golang.org/x/text v0.40.0
 	golang.org/x/time v0.15.0
 	k8s.io/api v0.36.2

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,6 @@ github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhM
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
-github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
@@ -97,8 +95,6 @@ github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 go.starlark.net v0.0.0-20260210143700-b62fd896b91b h1:mDO9/2PuBcapqFbhiCmFcEQZvlQnk3ILEZR+a8NL1z4=
 go.starlark.net v0.0.0-20260210143700-b62fd896b91b/go.mod h1:YKMCv9b1WrfWmeqdV5MAuEHWsu5iC+fe6kYl2sQjdI8=
-go.uber.org/automaxprocs v1.5.3 h1:kWazyxZUrS3Gs4qUpbwo5kEIMGe/DAvi5Z4tl2NW4j8=
-go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ import (
 	clientset "github.com/kubernetes-sigs/resource-state-metrics/pkg/generated/clientset/versioned"
 	"github.com/kubernetes-sigs/resource-state-metrics/pkg/options"
 	"github.com/kubernetes-sigs/resource-state-metrics/pkg/signals"
-	"go.uber.org/automaxprocs/maxprocs"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -45,15 +44,6 @@ func main() {
 
 	options := options.NewOptions(logger)
 	options.Read()
-
-	// Set GOMAXPROCS based on CPU quota.
-	if *options.AutoGOMAXPROCS {
-		unset, err := maxprocs.Set(maxprocs.Logger(klog.Infof))
-		if err != nil {
-			logger.Error(err, "Error setting GOMAXPROCS")
-			unset()
-		}
-	}
 
 	// Set GOMEMLIMIT based on memory quota.
 	slogger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -31,7 +31,6 @@ import (
 var (
 	flagOnce sync.Once
 	// Registered flag values.
-	registeredAutoGOMAXPROCS             *bool
 	registeredCardinalityWarningRatio    *float64
 	registeredCELCostLimit               *uint64
 	registeredCELTimeout                 *int
@@ -51,7 +50,6 @@ var (
 )
 
 const (
-	autoGOMAXPROCSFlagName             = "auto-gomaxprocs"
 	cardinalityWarningRatioFlagName    = "cardinality-warning-ratio"
 	celCostLimitFlagName               = "cel-cost-limit"
 	celTimeoutFlagName                 = "cel-timeout-seconds"
@@ -83,7 +81,6 @@ const (
 
 // Options represents the command-line Options.
 type Options struct {
-	AutoGOMAXPROCS             *bool
 	CardinalityWarningRatio    *float64
 	CELCostLimit               *uint64
 	CELTimeout                 *int
@@ -117,7 +114,6 @@ func (o *Options) Read() {
 	// Register flags only once to avoid "flag redefined" panics when multiple
 	// Options instances call Read() (e.g., in parallel tests).
 	flagOnce.Do(func() {
-		registeredAutoGOMAXPROCS = flag.Bool(autoGOMAXPROCSFlagName, true, "Automatically set GOMAXPROCS to match CPU quota.")
 		//nolint:lll
 		registeredCardinalityWarningRatio = flag.Float64(cardinalityWarningRatioFlagName, DefaultCardinalityWarningRatio, "Ratio of cardinality threshold at which to emit warning conditions (0.0-1.0). Default 0.8 means warnings start at 80% of threshold.")
 		//nolint:lll
@@ -171,7 +167,6 @@ func (o *Options) Read() {
 	})
 
 	// Copy registered values to this Options instance
-	o.AutoGOMAXPROCS = registeredAutoGOMAXPROCS
 	o.CardinalityWarningRatio = registeredCardinalityWarningRatio
 	o.CELCostLimit = registeredCELCostLimit
 	o.CELTimeout = registeredCELTimeout


### PR DESCRIPTION
## Summary

go 1.25+ is aware of maxprocs, so doesn't need this dependency anymore.

https://go.dev/doc/go1.25#container-aware-gomaxprocs

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)
