### PR TITLE
fix: tear down stores when a ResourceMetricsMonitor is deleted

### DIFF
--- a/internal/controller.go
+++ b/internal/controller.go
@@ -41,6 +41,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
@@ -63,6 +64,16 @@ const (
 
 // schemeOnce ensures scheme registration happens only once (thread-safe for parallel tests).
 var schemeOnce sync.Once
+
+// workItem is a single workqueue entry. uid is captured at enqueue time,
+// rather than re-derived when the item is processed, because a deleteEvent's
+// underlying resource is already gone from both the API server and the
+// informer cache by the time syncHandler runs, and c.stores is keyed by UID.
+type workItem struct {
+	key   string
+	event string
+	uid   types.UID
+}
 
 // NOTE: When adding new metrics, consider revisiting the alerting mixins.
 type metrics struct {
@@ -90,7 +101,7 @@ type Controller struct {
 	dynamicClientset         dynamic.Interface
 	resourceDiscovery        ResourceDiscovery
 	rsmInformerFactory       informers.SharedInformerFactory
-	workqueue                workqueue.TypedRateLimitingInterface[[2]string]
+	workqueue                workqueue.TypedRateLimitingInterface[workItem]
 	recorder                 record.EventRecorder
 	stores                   sync.Map
 	options                  *options.Options
@@ -123,8 +134,8 @@ func NewController(
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: version.ControllerName.String()})
 
 	ratelimiter := workqueue.NewTypedMaxOfRateLimiter(
-		workqueue.NewTypedItemExponentialFailureRateLimiter[[2]string](rateLimiterBaseDelay, rateLimiterMaxDelay),
-		&workqueue.TypedBucketRateLimiter[[2]string]{Limiter: rate.NewLimiter(rate.Limit(rateLimiterQPS), rateLimiterBurst)},
+		workqueue.NewTypedItemExponentialFailureRateLimiter[workItem](rateLimiterBaseDelay, rateLimiterMaxDelay),
+		&workqueue.TypedBucketRateLimiter[workItem]{Limiter: rate.NewLimiter(rate.Limit(rateLimiterQPS), rateLimiterBurst)},
 	)
 
 	controller := &Controller{
@@ -133,7 +144,7 @@ func NewController(
 		dynamicClientset:   dynamicClientset,
 		resourceDiscovery:  NewResourceDiscovery(discoveryClient, logger),
 		rsmInformerFactory: informers.NewSharedInformerFactory(rsmClientset, 0),
-		workqueue:          workqueue.NewTypedRateLimitingQueue[[2]string](ratelimiter),
+		workqueue:          workqueue.NewTypedRateLimitingQueue[workItem](ratelimiter),
 		recorder:           recorder,
 		options:            options,
 		globalCardinalityManager: NewGlobalCardinalityManager(
@@ -348,41 +359,55 @@ func (c *Controller) updateHandler(logger klog.Logger) func(interface{}, interfa
 }
 
 func (c *Controller) enqueue(obj interface{}, event eventType) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	object, ok := obj.(metav1.Object)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("error decoding object, invalid type %T", obj))
+
+			return
+		}
+
+		object, ok = tombstone.Obj.(metav1.Object)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type %T", tombstone.Obj))
+
+			return
+		}
+	}
+
+	key, err := cache.MetaNamespaceKeyFunc(object)
 	if err != nil {
 		utilruntime.HandleError(err)
 
 		return
 	}
 
-	c.workqueue.Add([2]string{key, event.String()})
+	c.workqueue.Add(workItem{key: key, event: event.String(), uid: object.GetUID()})
 }
 
 func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	logger := klog.FromContext(ctx)
 
-	objectWithEvent, shutdown := c.workqueue.Get()
+	item, shutdown := c.workqueue.Get()
 	if shutdown {
 		return false
 	}
 
-	err := func(objectWithEvent [2]string) error {
-		defer c.workqueue.Done(objectWithEvent)
+	err := func(item workItem) error {
+		defer c.workqueue.Done(item)
 
-		key := objectWithEvent[0]
-		event := objectWithEvent[1]
+		if err := c.syncHandler(ctx, item.key, item.event, item.uid); err != nil {
+			c.workqueue.AddRateLimited(item)
 
-		if err := c.syncHandler(ctx, key, event); err != nil {
-			c.workqueue.AddRateLimited(objectWithEvent)
-
-			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
+			return fmt.Errorf("error syncing '%s': %s, requeuing", item.key, err.Error())
 		}
 
-		c.workqueue.Forget(objectWithEvent)
-		logger.V(4).Info("Synced", "key", key)
+		c.workqueue.Forget(item)
+		logger.V(4).Info("Synced", "key", item.key)
 
 		return nil
-	}(objectWithEvent)
+	}(item)
 	if err != nil {
 		logger.Error(err, "error processing item")
 
@@ -392,7 +417,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
-func (c *Controller) syncHandler(ctx context.Context, key string, event string) error {
+func (c *Controller) syncHandler(ctx context.Context, key string, event string, uid types.UID) error {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("Syncing", "key", key, "event", event)
 
@@ -409,8 +434,13 @@ func (c *Controller) syncHandler(ctx context.Context, key string, event string) 
 	}
 
 	if errors.IsNotFound(err) {
+		// The resource is already gone from the API server and the informer
+		// cache by the time delete events are processed, so its identity has
+		// to be reconstructed from what enqueue captured beforehand.
 		resource = &v1alpha1.ResourceMetricsMonitor{}
+		resource.SetNamespace(namespace)
 		resource.SetName(name)
+		resource.SetUID(uid)
 	}
 
 	return c.handleObject(ctx, resource, event)

--- a/internal/events.go
+++ b/internal/events.go
@@ -53,13 +53,38 @@ func (e eventType) String() string {
 	return []string{"addEvent", "updateEvent", "deleteEvent"}[e]
 }
 
-func (c *Controller) handleEvent(ctx context.Context, stores *sync.Map, event string, o metav1.Object) error {
+func (c *Controller) handleEvent(ctx context.Context, stores *sync.Map, event string, object metav1.Object) error {
 	logger := klog.FromContext(ctx)
 
-	resource, err := c.validateAndPrepareResource(ctx, o, event)
+	// Deletes skip validateAndPrepareResource/emitSuccess entirely: the
+	// resource is already gone from the API server by the time a delete event
+	// is processed, so any Get/UpdateStatus against it would always fail with
+	// NotFound, short-circuiting handleEvent before the stores were torn down.
+	if event == deleteEvent.String() {
+		resource, ok := object.(*v1alpha1.ResourceMetricsMonitor)
+		if !ok {
+			logger.Error(errors.New("failed to cast object to ResourceMetricsMonitor"), "cannot handle event")
+			c.eventsProcessed.WithLabelValues(object.GetNamespace(), object.GetName(), event, "failed").Inc()
+
+			return nil
+		}
+
+		if err := c.processDelete(stores, resource); err != nil {
+			logger.Error(err, "event processing failed")
+			c.eventsProcessed.WithLabelValues(resource.GetNamespace(), resource.GetName(), event, "failed").Inc()
+
+			return nil
+		}
+
+		c.eventsProcessed.WithLabelValues(resource.GetNamespace(), resource.GetName(), event, "success").Inc()
+
+		return nil
+	}
+
+	resource, err := c.validateAndPrepareResource(ctx, object, event)
 	if err != nil {
 		logger.Error(err, "resource validation and preparation failed")
-		c.eventsProcessed.WithLabelValues(o.GetNamespace(), o.GetName(), event, "failed").Inc()
+		c.eventsProcessed.WithLabelValues(object.GetNamespace(), object.GetName(), event, "failed").Inc()
 
 		return nil
 	}
@@ -189,19 +214,60 @@ func (c *Controller) processAddOrUpdate(ctx context.Context, stores *sync.Map, _
 }
 
 func (c *Controller) processDelete(stores *sync.Map, resource *v1alpha1.ResourceMetricsMonitor) error {
+	namespace, name := resource.GetNamespace(), resource.GetName()
+
+	if storesI, ok := stores.Load(resource.GetUID()); ok {
+		if storesList, ok := storesI.([]*StoreType); ok {
+			c.deleteStoreCardinalityMetrics(namespace, name, storesList)
+		}
+	}
+
 	stores.Delete(resource.GetUID())
-	c.resourcesMonitored.DeleteLabelValues(resource.GetNamespace(), resource.GetName())
+	c.resourcesMonitored.DeleteLabelValues(namespace, name)
 
 	// Clean up cardinality tracking
 	c.globalCardinalityManager.DeleteResource(resource.GetUID())
 
 	// Clean up cardinality metrics
-	c.resourceCardinality.DeleteLabelValues(resource.GetNamespace(), resource.GetName())
+	c.resourceCardinality.DeleteLabelValues(namespace, name)
+	c.resourceCardinalityLimit.DeleteLabelValues(namespace, name)
 
 	// Update global cardinality metric
 	c.globalCardinality.Set(float64(c.globalCardinalityManager.GetGlobalTotal()))
 
 	return nil
+}
+
+// deleteStoreCardinalityMetrics removes the per-store and per-family
+// cardinality gauges (and their limits and duplicate counters) for a
+// resource's stores, mirroring the label sets aggregateStoreCardinality and
+// configurer.build populate them with.
+func (c *Controller) deleteStoreCardinalityMetrics(namespace, name string, storesList []*StoreType) {
+	for _, store := range storesList {
+		storeID := store.GetStoreIdentifier()
+		c.storeCardinality.DeleteLabelValues(namespace, name, storeID)
+		c.storeCardinalityLimit.DeleteLabelValues(namespace, name, storeID)
+		c.duplicateStores.DeleteLabelValues(namespace, name, storeID)
+
+		if store.cardinalityTracker == nil {
+			continue
+		}
+
+		// Union cardinalities and thresholds: a family only gets a
+		// cardinality entry once it has generated at least one sample, and
+		// only gets a threshold entry when it has a non-zero CardinalityLimit
+		// (see builder.go), so neither map alone is guaranteed complete.
+		families := store.cardinalityTracker.GetAllFamilyCardinalities()
+		for family := range store.cardinalityTracker.GetAllFamilyThresholds() {
+			families[family] = 0
+		}
+
+		for family := range families {
+			c.familyCardinality.DeleteLabelValues(namespace, name, "", family)
+			c.familyCardinalityLimit.DeleteLabelValues(namespace, name, "", family)
+			c.duplicateFamilies.DeleteLabelValues(namespace, name, family)
+		}
+	}
 }
 
 func (c *Controller) emitSuccess(ctx context.Context, monitor *v1alpha1.ResourceMetricsMonitor, statusBool metav1.ConditionStatus, message string) (*v1alpha1.ResourceMetricsMonitor, error) {

--- a/internal/events_test.go
+++ b/internal/events_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The Kubernetes resource-state-metrics Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/kubernetes-sigs/resource-state-metrics/pkg/apis/resourcestatemetrics/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+// newTestController returns a Controller with just enough state initialized
+// to exercise handleEvent's delete path: the metrics processDelete touches,
+// and the cardinality manager. It deliberately leaves rsmClientset nil, since
+// a correctly handled delete must never need to reach the API server.
+func newTestController() *Controller {
+	return &Controller{
+		globalCardinalityManager: NewGlobalCardinalityManager(0, 0, 0),
+		metrics: metrics{
+			resourcesMonitored:       prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "resources_monitored_info", Help: "test"}, []string{"namespace", "name"}),
+			eventsProcessed:          prometheus.NewCounterVec(prometheus.CounterOpts{Name: "events_processed_total", Help: "test"}, []string{"namespace", "name", "event_type", "status"}),
+			resourceCardinality:      prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "resource_cardinality", Help: "test"}, []string{"namespace", "name"}),
+			resourceCardinalityLimit: prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "resource_cardinality_limit", Help: "test"}, []string{"namespace", "name"}),
+			storeCardinality:         prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "store_cardinality", Help: "test"}, []string{"namespace", "name", "store"}),
+			storeCardinalityLimit:    prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "store_cardinality_limit", Help: "test"}, []string{"namespace", "name", "store"}),
+			familyCardinality:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "family_cardinality", Help: "test"}, []string{"namespace", "name", "store", "family"}),
+			familyCardinalityLimit:   prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "family_cardinality_limit", Help: "test"}, []string{"namespace", "name", "store", "family"}),
+			duplicateStores:          prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "duplicate_stores", Help: "test"}, []string{"namespace", "name", "store"}),
+			duplicateFamilies:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "duplicate_families", Help: "test"}, []string{"namespace", "name", "family"}),
+			globalCardinality:        prometheus.NewGauge(prometheus.GaugeOpts{Name: "global_cardinality", Help: "test"}),
+		},
+	}
+}
+
+// TestHandleEvent_DeleteTearsDownStore reproduces the "deleting an RMM never
+// tears down its stores" issue: a store is seeded under a resource's UID,
+// then a deleteEvent is fired through handleEvent for a resource the API
+// server no longer has (rsmClientset is nil here, so any Get/UpdateStatus
+// call would panic, exactly mirroring what a real NotFound would trigger).
+// Before the fix, handleEvent always called validateAndPrepareResource
+// first, which would fail for a deleted resource and return before
+// processDelete ever ran, leaking the store.
+func TestHandleEvent_DeleteTearsDownStore(t *testing.T) {
+	t.Parallel()
+
+	c := newTestController()
+
+	uid := uuid.NewUUID()
+	resource := &v1alpha1.ResourceMetricsMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deleted-rmm",
+			Namespace: "default",
+			UID:       uid,
+		},
+	}
+
+	var stores sync.Map
+	stores.Store(uid, []*StoreType{})
+
+	if err := c.handleEvent(context.Background(), &stores, deleteEvent.String(), resource); err != nil {
+		t.Fatalf("handleEvent returned an error: %v", err)
+	}
+
+	if _, ok := stores.Load(uid); ok {
+		t.Fatalf("store for UID %q still present after delete event; handleEvent did not tear it down", uid)
+	}
+}

--- a/internal/leak_bench_test.go
+++ b/internal/leak_bench_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026 The Kubernetes resource-state-metrics Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/resource-state-metrics/pkg/apis/resourcestatemetrics/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// newCardinalityBenchController builds a Controller with just enough state
+// to exercise processDelete/handleEvent's delete path, standalone from any
+// other test file's fixtures, so this file can be dropped into either side
+// of PR #67 unmodified to compare pre-fix vs post-fix behavior.
+func newCardinalityBenchController() *Controller {
+	return &Controller{
+		globalCardinalityManager: NewGlobalCardinalityManager(0, 0, 0),
+		metrics: metrics{
+			resourcesMonitored:       prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "resources_monitored_info", Help: "test"}, []string{"namespace", "name"}),
+			eventsProcessed:          prometheus.NewCounterVec(prometheus.CounterOpts{Name: "events_processed_total", Help: "test"}, []string{"namespace", "name", "event_type", "status"}),
+			resourceCardinality:      prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "resource_cardinality", Help: "test"}, []string{"namespace", "name"}),
+			resourceCardinalityLimit: prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "resource_cardinality_limit", Help: "test"}, []string{"namespace", "name"}),
+			storeCardinality:         prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "store_cardinality", Help: "test"}, []string{"namespace", "name", "store"}),
+			storeCardinalityLimit:    prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "store_cardinality_limit", Help: "test"}, []string{"namespace", "name", "store"}),
+			familyCardinality:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "family_cardinality", Help: "test"}, []string{"namespace", "name", "store", "family"}),
+			familyCardinalityLimit:   prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "family_cardinality_limit", Help: "test"}, []string{"namespace", "name", "store", "family"}),
+			duplicateStores:          prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "duplicate_stores", Help: "test"}, []string{"namespace", "name", "store"}),
+			duplicateFamilies:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "duplicate_families", Help: "test"}, []string{"namespace", "name", "family"}),
+			globalCardinality:        prometheus.NewGauge(prometheus.GaugeOpts{Name: "global_cardinality", Help: "test"}),
+			globalCardinalityLimit:   prometheus.NewGauge(prometheus.GaugeOpts{Name: "global_cardinality_limit", Help: "test"}),
+		},
+	}
+}
+
+// seedResourceCardinality simulates what configurer.build + processAddOrUpdate
+// leave behind for one RMM with one store and one family: a StoreType with a
+// populated CardinalityTracker, plus the resourcesMonitored/storeCardinality/
+// familyCardinality/duplicateStores/duplicateFamilies series that
+// aggregateStoreCardinality+updateCardinalityMetrics produce for it.
+func seedResourceCardinality(c *Controller, stores *sync.Map, namespace, name string, uid types.UID) *v1alpha1.ResourceMetricsMonitor {
+	resource := &v1alpha1.ResourceMetricsMonitor{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: uid},
+	}
+
+	store := &StoreType{Group: "example.com", Version: "v1", Kind: "Widget"}
+	tracker := NewCardinalityTracker(1000, 0.8)
+	tracker.SetFamilyThreshold("widget_info", 500)
+	tracker.Update(uid, map[string]int64{"widget_info": 10})
+	store.SetCardinalityTracker(tracker)
+
+	storesList := []*StoreType{store}
+	stores.Store(uid, storesList)
+
+	agg := c.aggregateStoreCardinality(storesList, resource)
+	c.updateCardinalityMetrics(resource, agg)
+
+	storeID := store.GetStoreIdentifier()
+	c.duplicateStores.WithLabelValues(namespace, name, storeID).Set(0)
+	c.duplicateFamilies.WithLabelValues(namespace, name, "widget_info").Set(0)
+	c.resourcesMonitored.WithLabelValues(namespace, name).Set(1)
+
+	return resource
+}
+
+// TestDeleteCycle_NoLeak runs many create+delete cycles of distinct RMMs
+// (distinct namespace/name/UID per iteration, mirroring a fleet of
+// short-lived RMMs churning in a real cluster) directly through
+// processDelete, then asserts every cardinality-related gauge is back to
+// zero series. Before PR #67, processDelete never removed storeCardinality,
+// storeCardinalityLimit, familyCardinality, familyCardinalityLimit,
+// duplicateStores or duplicateFamilies, so each iteration left one more
+// label combination behind permanently; this test fails against the
+// pre-fix processDelete (see BenchmarkDeleteCycle for the routing half of
+// the bug, fixed in handleEvent/syncHandler).
+func TestDeleteCycle_NoLeak(t *testing.T) {
+	t.Parallel()
+
+	c := newCardinalityBenchController()
+
+	var stores sync.Map
+
+	const n = 500
+	for i := range n {
+		namespace, name := "default", fmt.Sprintf("rmm-%d", i)
+		uid := types.UID(fmt.Sprintf("uid-%d", i))
+
+		resource := seedResourceCardinality(c, &stores, namespace, name, uid)
+
+		if err := c.processDelete(&stores, resource); err != nil {
+			t.Fatalf("processDelete: %v", err)
+		}
+	}
+
+	for name, vec := range map[string]*prometheus.GaugeVec{
+		"store_cardinality":          c.storeCardinality,
+		"store_cardinality_limit":    c.storeCardinalityLimit,
+		"family_cardinality":         c.familyCardinality,
+		"family_cardinality_limit":   c.familyCardinalityLimit,
+		"duplicate_stores":           c.duplicateStores,
+		"duplicate_families":         c.duplicateFamilies,
+		"resource_cardinality":       c.resourceCardinality,
+		"resource_cardinality_limit": c.resourceCardinalityLimit,
+	} {
+		if got := testutil.CollectAndCount(vec); got != 0 {
+			t.Errorf("%s: %d leaked series remain after %d create+delete cycles, want 0", name, got, n)
+		}
+	}
+}
+
+// TestDeleteCycle_NoGoroutineLeak runs many create+delete cycles through the
+// full handleEvent path (the production entry point for deleteEvent) and
+// asserts the goroutine count doesn't grow. processAddOrUpdate spawns a
+// background goroutine per resource to poll cardinality status, but the
+// delete path added/fixed in PR #67 (processDelete, and handleEvent's
+// deleteEvent branch) doesn't start any goroutines of its own, so this is
+// mostly a guard against a future regression rather than evidence of a
+// pre-fix leak — deliberately not run with t.Parallel, since
+// runtime.NumGoroutine reflects the whole test binary and would be noisy
+// alongside concurrently running subtests.
+func TestDeleteCycle_NoGoroutineLeak(t *testing.T) {
+	c := newCardinalityBenchController()
+
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	const n = 200
+	for i := range n {
+		var stores sync.Map
+
+		namespace, name := "default", fmt.Sprintf("rmm-goroutine-%d", i)
+		uid := types.UID(fmt.Sprintf("uid-goroutine-%d", i))
+
+		resource := seedResourceCardinality(c, &stores, namespace, name, uid)
+
+		if err := c.handleEvent(context.Background(), &stores, deleteEvent.String(), resource); err != nil {
+			t.Fatalf("handleEvent: %v", err)
+		}
+	}
+
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	if after > before {
+		t.Errorf("goroutine count grew from %d to %d after %d create+delete cycles", before, after, n)
+	}
+}
+
+// BenchmarkProcessDelete profiles just the cleanup step (stores.Delete +
+// gauge teardown), which is safe to run unmodified against both sides of
+// PR #67: unlike handleEvent, it never touches rsmClientset. This isolates
+// the CPU/alloc cost PR #67 *adds* to a delete (the new per-store,
+// per-family gauge cleanup loop) from the network calls it *removes*
+// (below).
+func BenchmarkProcessDelete(b *testing.B) {
+	c := newCardinalityBenchController()
+
+	b.ReportAllocs()
+
+	for i := 0; b.Loop(); i++ {
+		var stores sync.Map
+
+		namespace, name := "default", fmt.Sprintf("rmm-%d", i)
+		uid := types.UID(fmt.Sprintf("uid-%d", i))
+
+		resource := seedResourceCardinality(c, &stores, namespace, name, uid)
+
+		if err := c.processDelete(&stores, resource); err != nil {
+			b.Fatalf("processDelete: %v", err)
+		}
+	}
+}
+
+// BenchmarkDeleteCycle profiles a full create+delete cycle through
+// handleEvent (the routing entry point deleteEvent goes through in
+// production). This only runs post-fix: pre-fix, handleEvent
+// unconditionally calls validateAndPrepareResource first, which
+// unconditionally dereferences rsmClientset — a hard, avoidable runtime
+// dependency on a live API server that this offline benchmark deliberately
+// has none of (see newCardinalityBenchController), so it panics rather than
+// producing a number. That asymmetry is itself the point: pre-fix, there is
+// no way to locally benchmark a delete's CPU cost at all, because the cost
+// that dominates it is a network round trip, not CPU — which is also why a
+// CPU pprof profile isn't the right instrument for what this PR removes.
+func BenchmarkDeleteCycle(b *testing.B) {
+	c := newCardinalityBenchController()
+
+	b.ReportAllocs()
+
+	for i := 0; b.Loop(); i++ {
+		var stores sync.Map
+
+		namespace, name := "default", fmt.Sprintf("rmm-%d", i)
+		uid := types.UID(fmt.Sprintf("uid-%d", i))
+
+		resource := seedResourceCardinality(c, &stores, namespace, name, uid)
+
+		if err := c.handleEvent(context.Background(), &stores, deleteEvent.String(), resource); err != nil {
+			b.Fatalf("handleEvent: %v", err)
+		}
+	}
+}

--- a/tests/lifecycle_test.go
+++ b/tests/lifecycle_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2026 The Kubernetes resource-state-metrics Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This test validates that deleting a ResourceMetricsMonitor tears down its
+stores end-to-end: its series must stop being served on the main metrics
+endpoint, and its resources_monitored_info telemetry gauge must be cleaned
+up. This can't be expressed as a tests/golden/*.yaml rule, since golden rules
+describe a single static input/output pair, not a create-then-delete
+sequence.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/resource-state-metrics/pkg/apis/resourcestatemetrics/v1alpha1"
+	"github.com/kubernetes-sigs/resource-state-metrics/tests/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+// TestResourceMetricsMonitorDeletion verifies that deleting an RMM removes
+// its series from the main metrics endpoint and cleans up its
+// resources_monitored_info telemetry gauge.
+func TestResourceMetricsMonitorDeletion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	const (
+		namespace  = "default"
+		name       = "delete-teardown-test"
+		familyName = "rmm_delete_teardown_test"
+	)
+
+	rmm := &v1alpha1.ResourceMetricsMonitor{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "resource-state-metrics.instrumentation.k8s-sigs.io/v1alpha1",
+			Kind:       "ResourceMetricsMonitor",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       uuid.NewUUID(),
+		},
+		Spec: v1alpha1.ResourceMetricsMonitorSpec{
+			Configuration: v1alpha1.Configuration{
+				Stores: []v1alpha1.Store{
+					{
+						Group:    "samplecontroller.k8s.io",
+						Version:  "v1beta1",
+						Kind:     "Bar",
+						Resource: "bars",
+						Resolver: v1alpha1.ResolverTypeUnstructured,
+						Families: []v1alpha1.Family{
+							{
+								Name: familyName,
+								Help: "Test metric verifying store teardown on RMM deletion.",
+								Metrics: []v1alpha1.Metric{
+									{
+										Labels: []v1alpha1.Label{
+											{Name: "name", Value: "metadata.name"},
+										},
+										Value: "1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	f := framework.NewInforming(ctx, rmm)
+
+	if err := applyCRDManifests(ctx, t, f); err != nil {
+		t.Fatalf("Failed to apply CRD manifests: %v", err)
+	}
+
+	gvrToKindListMap := make(map[schema.GroupVersionResource]string)
+	indexedCRDs := f.GetIndexedCRDs()
+
+	for _, crd := range indexedCRDs {
+		for _, version := range crd.Spec.Versions {
+			gv := schema.GroupVersion{Group: crd.Spec.Group, Version: version.Name}
+
+			f.AddToScheme(func(scheme *runtime.Scheme) {
+				scheme.AddKnownTypes(gv, &unstructured.Unstructured{}, &unstructured.UnstructuredList{})
+			})
+
+			gvr := schema.GroupVersionResource{
+				Group:    crd.Spec.Group,
+				Version:  version.Name,
+				Resource: crd.Spec.Names.Plural,
+			}
+			gvrToKindListMap[gvr] = crd.Spec.Names.Kind + "List"
+		}
+	}
+
+	f.WithDynamicClient(gvrToKindListMap)
+
+	if err := applyCRManifests(ctx, t, f); err != nil {
+		t.Fatalf("Failed to apply CR manifests: %v", err)
+	}
+
+	if err := f.Start(ctx, 1); err != nil {
+		t.Fatalf("Failed to start controller: %v", err)
+	}
+
+	// Wait for the controller to process the RMM and populate the store.
+	time.Sleep(5 * framework.LongTimeInterval)
+
+	metricsOutput, err := f.FetchMainMetrics(ctx)
+	if err != nil {
+		t.Fatalf("Failed to fetch main metrics: %v", err)
+	}
+
+	if !strings.Contains(metricsOutput, familyName) {
+		t.Fatalf("Expected metric family %q to be present before deletion, got:\n%s", familyName, metricsOutput)
+	}
+
+	// Anchored on the metric name so it can't accidentally match an unrelated
+	// series that happens to share the same namespace/name label values (e.g.
+	// events_processed_total, which is a historical counter and is expected
+	// to persist after deletion).
+	resourcesMonitoredSeries := fmt.Sprintf("resource_state_metrics_resources_monitored_info{name=%q,namespace=%q}", name, namespace)
+
+	telemetryBefore, err := f.FetchTelemetryMetrics(ctx)
+	if err != nil {
+		t.Fatalf("Failed to fetch telemetry metrics: %v", err)
+	}
+
+	if !strings.Contains(telemetryBefore, resourcesMonitoredSeries) {
+		t.Fatalf("Expected resources_monitored_info to reference the RMM before deletion, got:\n%s", telemetryBefore)
+	}
+
+	if err := f.RSMClient.ResourceStateMetricsV1alpha1().ResourceMetricsMonitors(namespace).
+		Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Failed to delete RMM: %v", err)
+	}
+
+	waitUntilMainMetricsExclude(ctx, t, f, familyName)
+
+	telemetryAfter, err := f.FetchTelemetryMetrics(ctx)
+	if err != nil {
+		t.Fatalf("Failed to fetch telemetry metrics: %v", err)
+	}
+
+	if strings.Contains(telemetryAfter, resourcesMonitoredSeries) {
+		t.Fatalf("Expected resources_monitored_info to no longer reference the deleted RMM, got:\n%s", telemetryAfter)
+	}
+}
+
+// waitUntilMainMetricsExclude polls the main metrics endpoint until it no
+// longer contains needle, or fails the test on timeout.
+func waitUntilMainMetricsExclude(ctx context.Context, t *testing.T, f *framework.Framework, needle string) {
+	t.Helper()
+
+	pollCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(framework.ShortTimeInterval)
+	defer ticker.Stop()
+
+	var lastOutput string
+
+	for {
+		select {
+		case <-pollCtx.Done():
+			t.Fatalf("Timed out waiting for %q to disappear from main metrics. Last output:\n%s", needle, lastOutput)
+
+			return
+		case <-ticker.C:
+			output, err := f.FetchMainMetrics(ctx)
+			if err != nil {
+				t.Fatalf("Failed to fetch main metrics: %v", err)
+			}
+
+			lastOutput = output
+
+			if !strings.Contains(output, needle) {
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION


## Summary



Deleting a `ResourceMetricsMonitor` never tore down its store: `handleEvent` unconditionally ran `validateAndPrepareResource` (a Get+UpdateStatus round trip against the API server) before dispatching to `processDelete`, and for delete events that always failed with `NotFound` since the resource is already gone  so `processDelete` never ran, and the RMM's series stayed on `/metrics` indefinitely. Separately, `syncHandler`'s `NotFound` fallback only set the reconstructed resource's `Name`, dropping `Namespace` and `UID`, so even a correctly-routed delete would have missed the store (`c.stores` is keyed by UID).

This patch:

- Threads the resource's UID through the workqueue (a new `workItem` struct  replacing the previous `[2]string` item), captured at enqueue time before the resource can be deleted out from under it, so `syncHandler` can correctly reconstruct the deleted resource's identity.
- Routes `deleteEvent` straight to `processDelete` in `handleEvent`, skipping the API-server calls that can never succeed for an already-deleted resource.
- Extends `processDelete` to also clean up the per-store and per-family cardinality gauges (`store_cardinality`, `store_cardinality_limit`,
`family_cardinality`, `family_cardinality_limit`, `duplicate_stores`,  `duplicate_families`, `resource_cardinality_limit`) it was previously
  leaving behind  a related gap uncovered while writing the end-to-end regression test.

Verified manually against a real `kind` cluster (deleted an RMM, confirmed series and telemetry gauges both disappeared) in addition to the automated tests below.

Fixes #66

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [x] Tests added or updated (if applicable)
