### PR TITLE
feat(logging): improve error reporting during metric generation

### DIFF
--- a/internal/events.go
+++ b/internal/events.go
@@ -390,6 +390,23 @@ func (c *Controller) updateCardinalityStatus(ctx context.Context, resource *v1al
 	c.updateCardinalityMetrics(resource, agg)
 	c.recordCardinalityViolations(resource, agg.violations)
 
+	for _, v := range agg.violations {
+		switch v.Severity {
+		case SeverityCutoff:
+			logger.Error(errors.New("cardinality threshold exceeded"), "metric generation cut off",
+				"level", v.Level,
+				"name", v.Name,
+				"current", v.Current,
+				"threshold", v.Threshold)
+		case SeverityWarning:
+			logger.V(1).Info("Cardinality threshold warning limit reached",
+				"level", v.Level,
+				"name", v.Name,
+				"current", v.Current,
+				"threshold", v.Threshold)
+		}
+	}
+
 	return c.persistCardinalityStatus(ctx, resource, agg)
 }
 

--- a/internal/events.go
+++ b/internal/events.go
@@ -393,7 +393,7 @@ func (c *Controller) updateCardinalityStatus(ctx context.Context, resource *v1al
 	for _, v := range agg.violations {
 		switch v.Severity {
 		case SeverityCutoff:
-			logger.Error(errors.New("cardinality threshold exceeded"), "metric generation cut off",
+			logger.Error(errors.New("cardinality threshold exceeded, cutoff pending"), "metric generation will be cut off on the next iteration",
 				"level", v.Level,
 				"name", v.Name,
 				"current", v.Current,

--- a/internal/family.go
+++ b/internal/family.go
@@ -176,7 +176,7 @@ func (f *FamilyType) buildMetricString(unstructured *unstructured.Unstructured) 
 
 			resolverInstance, err := f.resolver(metric.Resolver)
 			if err != nil {
-				logger.V(1).Error(fmt.Errorf("error resolving metric: %w", err), "skipping")
+				logger.Error(fmt.Errorf("error resolving metric: %w", err), "skipping")
 				putBuilder(metricRawBuilder)
 
 				continue
@@ -186,7 +186,7 @@ func (f *FamilyType) buildMetricString(unstructured *unstructured.Unstructured) 
 
 			resolvedValue, ok, err := resolveMetricValue(resolverInstance, metric.Value, unstructured.Object, resolvedExpandedLabelSet)
 			if err != nil {
-				logger.V(1).Error(fmt.Errorf("error resolving metric value %q: %w", metric.Value, err), "skipping")
+				logger.Error(fmt.Errorf("error resolving metric value %q: %w", metric.Value, err), "skipping")
 				putBuilder(metricRawBuilder)
 
 				continue
@@ -200,6 +200,7 @@ func (f *FamilyType) buildMetricString(unstructured *unstructured.Unstructured) 
 
 			samples, err := writeMetricSamplesWithCount(metricRawBuilder, f.Name, f.kind(), unstructured, resolvedLabelKeys, resolvedLabelValues, resolvedExpandedLabelSet, resolvedValue, logger)
 			if err != nil {
+				logger.Error(err, "failed to write metric samples, skipping metric")
 				putBuilder(metricRawBuilder)
 
 				continue
@@ -229,7 +230,7 @@ func (f *FamilyType) buildMetricStringFromStarlark(unstr *unstructured.Unstructu
 
 	families, err := f.starlarkResolver.Resolve(unstr.Object)
 	if err != nil {
-		logger.V(1).Error(err, "Starlark generation failed")
+		logger.Error(err, "Starlark generation failed")
 
 		return "", 0
 	}

--- a/pkg/resolver/cel.go
+++ b/pkg/resolver/cel.go
@@ -114,7 +114,7 @@ func (cr *CELResolver) Resolve(query string, unstructuredObjectMap map[string]in
 	select {
 	case res := <-resultChan:
 		if res.err != nil {
-			logger.V(1).Info("ignoring resolution for query", "info", res.err)
+			logger.Error(res.err, "CEL query evaluation failed")
 
 			if cr.expressionEvaluationMetric != nil {
 				cr.expressionEvaluationMetric.WithLabelValues(cr.managedRMMNamespace, cr.managedRMMName, cr.familyName, "error").Inc()


### PR DESCRIPTION
## Summary

This PR improves observability by surfacing previously silent or low-visibility failures during metric generation and evaluation.

Changes include:

- Log metric formatting, validation, and missing resolver configuration errors in `internal/family.go` instead of silently ignoring them.
- Promote Starlark script evaluation failures from verbose logs to `logger.Error` so they are visible with the default log level.
- Promote CEL evaluation failures to `logger.Error`, logging the evaluation error before falling back to the default mappings.
- Add logs for cardinality threshold warnings and cutoffs in `events.go` to make cardinality-related drops visible during runtime.

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (not applicable)
- [ ] Tests added or updated (not applicable)