### PR TITLE
fix(controller): resolve metrics lifecycle, label cleanup, and server shutdown bugs

### DIFF
--- a/internal/controller.go
+++ b/internal/controller.go
@@ -21,6 +21,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"net"
+	"net/http"
 	"reflect"
 	"strconv"
 	"sync"
@@ -59,6 +60,12 @@ const (
 	rateLimiterMaxDelay  = 5 * time.Minute
 	rateLimiterQPS       = 50
 	rateLimiterBurst     = 300
+
+	// shutdownTimeout is how long the HTTP servers are given to drain in-flight
+	// connections after the controller context is cancelled. Using the already-
+	// cancelled parent context would cause Shutdown to return immediately with
+	// context.Canceled, aborting active scrapes mid-flight.
+	shutdownTimeout = 30 * time.Second
 )
 
 // schemeOnce ensures scheme registration happens only once (thread-safe for parallel tests).
@@ -282,14 +289,18 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 	go func() {
 		logger.V(1).Info("Starting telemetry server on", "address", selfAddr)
 
-		if err := self.ListenAndServe(); err != nil {
+		// ErrServerClosed is the expected return value when Shutdown is called;
+		// treat it as a normal termination rather than an error.
+		if err := self.ListenAndServe(); err != nil && !stderrors.Is(err, http.ErrServerClosed) {
 			logger.Error(err, "stopping telemetry server")
 		}
 	}()
 	go func() {
 		logger.V(1).Info("Starting main server on", "address", mainAddr)
 
-		if err := main.ListenAndServe(); err != nil {
+		// ErrServerClosed is the expected return value when Shutdown is called;
+		// treat it as a normal termination rather than an error.
+		if err := main.ListenAndServe(); err != nil && !stderrors.Is(err, http.ErrServerClosed) {
 			logger.Error(err, "stopping main server")
 		}
 	}()
@@ -297,11 +308,19 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 	<-ctx.Done()
 	logger.V(1).Info("Shutting down servers")
 
-	if err := self.Shutdown(ctx); err != nil {
+	// Derive a non-cancelled context from parent ctx so that Shutdown can
+	// actually drain in-flight connections. Using the already-cancelled
+	// parent ctx directly would cause Shutdown to return immediately with
+	// context.Canceled, dropping active scrapes mid-flight. Using
+	// context.WithoutCancel inherits context values while ignoring cancellation.
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownTimeout)
+	defer shutdownCancel()
+
+	if err := self.Shutdown(shutdownCtx); err != nil {
 		logger.Error(err, "error shutting down telemetry server")
 	}
 
-	if err := main.Shutdown(ctx); err != nil {
+	if err := main.Shutdown(shutdownCtx); err != nil {
 		logger.Error(err, "error shutting down main server")
 	}
 

--- a/internal/events.go
+++ b/internal/events.go
@@ -189,16 +189,43 @@ func (c *Controller) processAddOrUpdate(ctx context.Context, stores *sync.Map, _
 }
 
 func (c *Controller) processDelete(stores *sync.Map, resource *v1alpha1.ResourceMetricsMonitor) error {
-	stores.Delete(resource.GetUID())
-	c.resourcesMonitored.DeleteLabelValues(resource.GetNamespace(), resource.GetName())
+	namespace := resource.GetNamespace()
+	name := resource.GetName()
 
-	// Clean up cardinality tracking
+	// Load stores before removing the entry so we can clean up per-store and
+	// per-family Prometheus label sets. These GaugeVec children are never
+	// removed automatically; without explicit deletion they accumulate for
+	// every RMM that is created and deleted, growing the registry without bound.
+	if storesI, ok := stores.Load(resource.GetUID()); ok {
+		if storeList, ok := storesI.([]*StoreType); ok {
+			for _, store := range storeList {
+				storeID := store.GetStoreIdentifier()
+
+				c.storeCardinality.DeleteLabelValues(namespace, name, storeID)
+				c.storeCardinalityLimit.DeleteLabelValues(namespace, name, storeID)
+				c.duplicateStores.DeleteLabelValues(namespace, name, storeID)
+
+				for i := range store.Families {
+					familyName := store.Families[i].Name
+					c.familyCardinality.DeleteLabelValues(namespace, name, "", familyName)
+					c.familyCardinalityLimit.DeleteLabelValues(namespace, name, "", familyName)
+					c.duplicateFamilies.DeleteLabelValues(namespace, name, familyName)
+				}
+			}
+		}
+	}
+
+	stores.Delete(resource.GetUID())
+	c.resourcesMonitored.DeleteLabelValues(namespace, name)
+
+	// Clean up per-resource Prometheus label sets.
+	c.resourceCardinality.DeleteLabelValues(namespace, name)
+	c.resourceCardinalityLimit.DeleteLabelValues(namespace, name)
+
+	// Clean up cardinality tracking.
 	c.globalCardinalityManager.DeleteResource(resource.GetUID())
 
-	// Clean up cardinality metrics
-	c.resourceCardinality.DeleteLabelValues(resource.GetNamespace(), resource.GetName())
-
-	// Update global cardinality metric
+	// Update global cardinality metric.
 	c.globalCardinality.Set(float64(c.globalCardinalityManager.GetGlobalTotal()))
 
 	return nil

--- a/internal/store.go
+++ b/internal/store.go
@@ -133,12 +133,49 @@ func (s *StoreType) Delete(objectI interface{}) error {
 }
 
 // Replace is called when the reflector does a resync or starts up and lists all existing objects.
+// It atomically replaces the full metrics set with the incoming items, removing any entries for
+// objects that have been deleted since the last list. The CardinalityTracker is reset and rebuilt
+// from scratch so that cardinality counts reflect only live objects.
 func (s *StoreType) Replace(items []interface{}, _ string) error {
-	for _, item := range items {
-		if err := s.Add(item); err != nil {
-			s.logger.Error(err, "failed to add item during replace")
-		}
+	// Hold the write lock for the entire Replace to match the locking contract
+	// of Add/Delete: generateMetricsForObject mutates family.Labels and
+	// family.logger in place, so it must not run concurrently with other
+	// store operations.
+	s.mutex.Lock()
+
+	newMetrics := make(map[types.UID][]string, len(items))
+
+	if s.cardinalityTracker != nil {
+		s.cardinalityTracker.Reset()
 	}
+
+	for _, item := range items {
+		obj, err := convertToUnstructured(item)
+		if err != nil {
+			s.logger.Error(err, "failed to convert item during replace")
+
+			continue
+		}
+
+		result := s.generateMetricsForObject(obj)
+		newMetrics[obj.GetUID()] = result.metrics
+
+		if s.cardinalityTracker != nil {
+			s.cardinalityTracker.Update(obj.GetUID(), result.perFamily)
+		}
+
+		s.logger.V(2).Info("Replace", "key", klog.KObj(obj))
+	}
+
+	// Atomically swap in the fresh map; any UID absent from items (i.e. the
+	// object was deleted between reflector lists) is no longer served.
+	s.metrics = newMetrics
+
+	if s.cardinalityTracker != nil {
+		s.checkAndApplyThresholds()
+	}
+
+	s.mutex.Unlock()
 
 	s.synced.Store(true)
 

--- a/internal/store_test.go
+++ b/internal/store_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 The Kubernetes resource-state-metrics Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package internal
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+// makeUnstructured is a helper that builds a minimal Unstructured object.
+func makeUnstructured(uid, name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+			"uid":       uid,
+		},
+	}}
+}
+
+// newTestStore creates a StoreType with no families (metrics will be empty
+// strings but the UID → metrics mapping will still be populated).
+func newTestStore() *StoreType {
+	return &StoreType{
+		logger:  klog.Background(),
+		metrics: map[types.UID][]string{},
+	}
+}
+
+// TestStoreReplace_ClearsStaleEntries verifies that Replace atomically
+// replaces the metrics map: objects absent from the replacement list (i.e.
+// deleted from Kubernetes since the last reflector list) must not appear in
+// the store after Replace returns.
+func TestStoreReplace_ClearsStaleEntries(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore()
+
+	objA := makeUnstructured("uid-a", "pod-a", "default")
+	objB := makeUnstructured("uid-b", "pod-b", "default")
+	objC := makeUnstructured("uid-c", "pod-c", "kube-system")
+
+	// Populate the store with three objects via Add.
+	if err := store.Add(objA); err != nil {
+		t.Fatalf("Add(objA): %v", err)
+	}
+
+	if err := store.Add(objB); err != nil {
+		t.Fatalf("Add(objB): %v", err)
+	}
+
+	if err := store.Add(objC); err != nil {
+		t.Fatalf("Add(objC): %v", err)
+	}
+
+	if got, want := len(store.metrics), 3; got != want {
+		t.Fatalf("before Replace: len(store.metrics) = %d, want %d", got, want)
+	}
+
+	// Replace with only objA and objB; objC has been deleted from Kubernetes.
+	if err := store.Replace([]interface{}{objA, objB}, ""); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+
+	store.mutex.RLock()
+	defer store.mutex.RUnlock()
+
+	if got, want := len(store.metrics), 2; got != want {
+		t.Fatalf("after Replace: len(store.metrics) = %d, want %d", got, want)
+	}
+
+	if _, ok := store.metrics[types.UID("uid-c")]; ok {
+		t.Error("after Replace: uid-c still present in store.metrics; stale entry was not cleared")
+	}
+
+	if _, ok := store.metrics[types.UID("uid-a")]; !ok {
+		t.Error("after Replace: uid-a missing from store.metrics")
+	}
+
+	if _, ok := store.metrics[types.UID("uid-b")]; !ok {
+		t.Error("after Replace: uid-b missing from store.metrics")
+	}
+}
+
+// TestStoreReplace_EmptyListClearsAll verifies that Replace with an empty
+// item list removes all metrics — e.g. when the watched resource type has
+// been completely purged.
+func TestStoreReplace_EmptyListClearsAll(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore()
+
+	obj := makeUnstructured("uid-x", "pod-x", "default")
+	if err := store.Add(obj); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := store.Replace([]interface{}{}, ""); err != nil {
+		t.Fatalf("Replace(empty): %v", err)
+	}
+
+	store.mutex.RLock()
+	defer store.mutex.RUnlock()
+
+	if got := len(store.metrics); got != 0 {
+		t.Fatalf("after Replace(empty): len(store.metrics) = %d, want 0", got)
+	}
+}
+
+// TestStoreReplace_SyncedAfterReplace verifies that IsSynced returns true
+// after a Replace call, matching the original behaviour.
+func TestStoreReplace_SyncedAfterReplace(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore()
+
+	if store.IsSynced() {
+		t.Fatal("store should not be synced before Replace")
+	}
+
+	if err := store.Replace([]interface{}{}, ""); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+
+	if !store.IsSynced() {
+		t.Fatal("store should be synced after Replace")
+	}
+}
+
+// TestStoreReplace_CardinalityTrackerReset verifies that the CardinalityTracker
+// is reset and rebuilt from the replacement set, so counts for deleted objects
+// are not carried forward.
+func TestStoreReplace_CardinalityTrackerReset(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore()
+
+	// Attach a cardinality tracker with a generous threshold.
+	tracker := NewCardinalityTracker(10000, 0.8)
+	store.SetCardinalityTracker(tracker)
+
+	objA := makeUnstructured("uid-a", "pod-a", "default")
+	objB := makeUnstructured("uid-b", "pod-b", "default")
+
+	if err := store.Add(objA); err != nil {
+		t.Fatalf("Add(objA): %v", err)
+	}
+
+	if err := store.Add(objB); err != nil {
+		t.Fatalf("Add(objB): %v", err)
+	}
+
+	// Replace with only objA; objB is gone.
+	if err := store.Replace([]interface{}{objA}, ""); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+
+	// The tracker should have no entry for uid-b.
+	tracker.mutex.RLock()
+	defer tracker.mutex.RUnlock()
+
+	if _, ok := tracker.perObject[types.UID("uid-b")]; ok {
+		t.Error("after Replace: uid-b still tracked in CardinalityTracker; stale count was not cleared")
+	}
+
+	if _, ok := tracker.perObject[types.UID("uid-a")]; !ok {
+		t.Error("after Replace: uid-a missing from CardinalityTracker")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #79

This PR addresses three closely related defects in the metrics lifecycle, Prometheus label tracking, and server graceful shutdown:

1. **Flush stale metrics in `StoreType.Replace()`**:
   - `StoreType.Replace()` previously iterated over incoming items and called `Add(item)` without clearing existing entries from `s.metrics` or resetting the `CardinalityTracker`. As a result, objects deleted from Kubernetes between reflector resyncs remained in memory and continued to be served on `/metrics`.
   - `Replace()` now atomically replaces `s.metrics` with a fresh map derived from the replacement items and resets the `CardinalityTracker`, purging stale entries.

2. **Clean up `GaugeVec` label series on RMM deletion**:
   - `processDelete()` in `internal/events.go` previously only removed `resourcesMonitored` and `resourceCardinality` label sets, leaking per-store and per-family cardinality child metrics (`storeCardinality`, `storeCardinalityLimit`, `familyCardinality`, `familyCardinalityLimit`, `resourceCardinalityLimit`, `duplicateStores`, `duplicateFamilies`).
   - `processDelete()` now retrieves active stores for the RMM before map deletion and explicitly calls `DeleteLabelValues()` for all associated `GaugeVec` metrics, preventing unbounded memory accumulation in the Prometheus registry.

3. **Graceful HTTP server shutdown context**:
   - `Controller.Run()` previously passed the already-cancelled parent `ctx` to `self.Shutdown(ctx)` and `main.Shutdown(ctx)`, causing `http.Server.Shutdown()` to return immediately with `context.Canceled` without draining in-flight requests.
   - `Shutdown` calls now use a fresh `context.WithTimeout(context.Background(), 30*time.Second)` to allow active scrapes to complete gracefully. Additionally, `http.ErrServerClosed` is filtered from error logging as expected shutdown output.

## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [x] Tests added or updated (if applicable)

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
