### PR TITLE
feat: cardinality tracking with per-store family metrics

### DIFF
--- a/internal/events.go
+++ b/internal/events.go
@@ -288,22 +288,26 @@ func (c *Controller) updateMetadata(ctx context.Context, resource *v1alpha1.Reso
 
 // cardinalityAggregation holds aggregated cardinality data from stores.
 type cardinalityAggregation struct {
-	totalCardinality int64
-	perStore         map[string]int64
-	perStoreLimit    map[string]int64
-	perFamily        map[string]int64
-	perFamilyLimit   map[string]int64
-	cutoffFamilies   []string
-	violations       []ThresholdViolation
+	totalCardinality    int64
+	perStore            map[string]int64
+	perStoreLimit       map[string]int64
+	perFamily           map[string]int64
+	perFamilyLimit      map[string]int64
+	perStoreFamily      map[string]map[string]int64
+	perStoreFamilyLimit map[string]map[string]int64
+	cutoffFamilies      []string
+	violations          []ThresholdViolation
 }
 
 // aggregateStoreCardinality aggregates cardinality data from all stores.
 func (c *Controller) aggregateStoreCardinality(stores []*StoreType, resource *v1alpha1.ResourceMetricsMonitor) cardinalityAggregation {
 	agg := cardinalityAggregation{
-		perStore:       make(map[string]int64),
-		perStoreLimit:  make(map[string]int64),
-		perFamily:      make(map[string]int64),
-		perFamilyLimit: make(map[string]int64),
+		perStore:            make(map[string]int64),
+		perStoreLimit:       make(map[string]int64),
+		perFamily:           make(map[string]int64),
+		perFamilyLimit:      make(map[string]int64),
+		perStoreFamily:      make(map[string]map[string]int64),
+		perStoreFamilyLimit: make(map[string]map[string]int64),
 	}
 
 	for _, store := range stores {
@@ -318,16 +322,27 @@ func (c *Controller) aggregateStoreCardinality(stores []*StoreType, resource *v1
 		agg.totalCardinality += storeTotal
 
 		familyCards := store.cardinalityTracker.GetAllFamilyCardinalities()
+		if len(familyCards) > 0 {
+			agg.perStoreFamily[storeID] = make(map[string]int64, len(familyCards))
+		}
+
 		for family, count := range familyCards {
 			agg.perFamily[family] += count
+			agg.perStoreFamily[storeID][family] = count
 		}
 
 		familyLimits := store.cardinalityTracker.GetAllFamilyThresholds()
+		if len(familyLimits) > 0 {
+			agg.perStoreFamilyLimit[storeID] = make(map[string]int64, len(familyLimits))
+		}
+
 		for family, limit := range familyLimits {
 			// Use max if family appears in multiple stores (unusual but possible)
 			if limit > agg.perFamilyLimit[family] {
 				agg.perFamilyLimit[family] = limit
 			}
+
+			agg.perStoreFamilyLimit[storeID][family] = limit
 		}
 
 		agg.cutoffFamilies = append(agg.cutoffFamilies, store.cardinalityTracker.GetCutoffFamilies()...)
@@ -450,13 +465,16 @@ func (c *Controller) updateCardinalityMetrics(resource *v1alpha1.ResourceMetrics
 		c.storeCardinalityLimit.WithLabelValues(namespace, name, storeID).Set(float64(limit))
 	}
 
-	for family, count := range agg.perFamily {
-		// We don't have per-store breakdown for family metrics here, so use empty store label.
-		c.familyCardinality.WithLabelValues(namespace, name, "", family).Set(float64(count))
+	for storeID, families := range agg.perStoreFamily {
+		for family, count := range families {
+			c.familyCardinality.WithLabelValues(namespace, name, storeID, family).Set(float64(count))
+		}
 	}
 
-	for family, limit := range agg.perFamilyLimit {
-		c.familyCardinalityLimit.WithLabelValues(namespace, name, "", family).Set(float64(limit))
+	for storeID, families := range agg.perStoreFamilyLimit {
+		for family, limit := range families {
+			c.familyCardinalityLimit.WithLabelValues(namespace, name, storeID, family).Set(float64(limit))
+		}
 	}
 
 	c.resourceCardinality.WithLabelValues(namespace, name).Set(float64(agg.totalCardinality))

--- a/internal/events.go
+++ b/internal/events.go
@@ -435,7 +435,7 @@ func (c *Controller) persistCardinalityStatus(ctx context.Context, resource *v1a
 	gotResource.Status.Cardinality = &v1alpha1.CardinalityStatus{
 		Total:              agg.totalCardinality,
 		PerStore:           agg.perStore,
-		PerFamily:          agg.perFamily,
+		PerFamily:          agg.perStoreFamily,
 		ThresholdsExceeded: hasThresholdExceeded(agg.violations),
 		CutoffFamilies:     agg.cutoffFamilies,
 		LastUpdated:        metav1.Now(),

--- a/manifests/custom-resource-definition.yaml
+++ b/manifests/custom-resource-definition.yaml
@@ -323,9 +323,12 @@ spec:
                     type: string
                   perFamily:
                     additionalProperties:
-                      format: int64
-                      type: integer
-                    description: PerFamily maps family names to their cardinality.
+                      additionalProperties:
+                        format: int64
+                        type: integer
+                      type: object
+                    description: PerFamily maps store identifiers to a map of family
+                      names and their cardinality.
                     type: object
                   perStore:
                     additionalProperties:

--- a/pkg/apis/resourcestatemetrics/v1alpha1/types.go
+++ b/pkg/apis/resourcestatemetrics/v1alpha1/types.go
@@ -301,8 +301,8 @@ type CardinalityStatus struct {
 	// PerStore maps store identifiers (group/version/kind) to their cardinality.
 	PerStore map[string]int64 `json:"perStore,omitempty"`
 
-	// PerFamily maps family names to their cardinality.
-	PerFamily map[string]int64 `json:"perFamily,omitempty"`
+	// PerFamily maps store identifiers to a map of family names and their cardinality.
+	PerFamily map[string]map[string]int64 `json:"perFamily,omitempty"`
 
 	// ThresholdsExceeded indicates whether any cardinality threshold has been exceeded.
 	ThresholdsExceeded bool `json:"thresholdsExceeded"`

--- a/pkg/apis/resourcestatemetrics/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/resourcestatemetrics/v1alpha1/zz_generated.deepcopy.go
@@ -38,9 +38,19 @@ func (in *CardinalityStatus) DeepCopyInto(out *CardinalityStatus) {
 	}
 	if in.PerFamily != nil {
 		in, out := &in.PerFamily, &out.PerFamily
-		*out = make(map[string]int64, len(*in))
+		*out = make(map[string]map[string]int64, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			var outVal map[string]int64
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make(map[string]int64, len(*in))
+				for key, val := range *in {
+					(*out)[key] = val
+				}
+			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.CutoffFamilies != nil {

--- a/tests/cardinality_test.go
+++ b/tests/cardinality_test.go
@@ -253,12 +253,15 @@ func TestFamilyCardinalityStoreLabel(t *testing.T) {
 	}
 
 	gvrToKindListMap := make(map[schema.GroupVersionResource]string)
+
 	for _, crd := range f.GetIndexedCRDs() {
 		for _, version := range crd.Spec.Versions {
 			gv := schema.GroupVersion{Group: crd.Spec.Group, Version: version.Name}
+
 			f.AddToScheme(func(scheme *runtime.Scheme) {
 				scheme.AddKnownTypes(gv, &unstructured.Unstructured{}, &unstructured.UnstructuredList{})
 			})
+
 			gvr := schema.GroupVersionResource{
 				Group:    crd.Spec.Group,
 				Version:  version.Name,
@@ -267,6 +270,7 @@ func TestFamilyCardinalityStoreLabel(t *testing.T) {
 			gvrToKindListMap[gvr] = crd.Spec.Names.Kind + "List"
 		}
 	}
+
 	f.WithDynamicClient(gvrToKindListMap)
 
 	if err := applyCRManifests(ctx, t, f); err != nil {

--- a/tests/cardinality_test.go
+++ b/tests/cardinality_test.go
@@ -189,6 +189,110 @@ func checkCardinalityExceededMetric(t *testing.T, metricsOutput string) {
 	}
 }
 
+// TestFamilyCardinalityStoreLabel verifies that resource_state_metrics_family_cardinality
+// never emits with an empty store label.
+func TestFamilyCardinalityStoreLabel(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	rmm := &v1alpha1.ResourceMetricsMonitor{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "resource-state-metrics.instrumentation.k8s-sigs.io/v1alpha1",
+			Kind:       "ResourceMetricsMonitor",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "family-cardinality-store-label-test",
+			Namespace: "default",
+			UID:       uuid.NewUUID(),
+		},
+		Spec: v1alpha1.ResourceMetricsMonitorSpec{
+			Configuration: v1alpha1.Configuration{
+				Stores: []v1alpha1.Store{
+					{
+						Group:    "samplecontroller.k8s.io",
+						Version:  "v1beta1",
+						Kind:     "Bar",
+						Resource: "bars",
+						Resolver: v1alpha1.ResolverTypeUnstructured,
+						Families: []v1alpha1.Family{
+							{
+								Name: "store_label_bar_test",
+								Help: "Bar metric for store-label test",
+								Metrics: []v1alpha1.Metric{
+									{Labels: []v1alpha1.Label{}, Value: "1"},
+								},
+							},
+						},
+					},
+					{
+						Group:    "samplecontroller.k8s.io",
+						Version:  "v1alpha1",
+						Kind:     "Foo",
+						Resource: "foos",
+						Resolver: v1alpha1.ResolverTypeUnstructured,
+						Families: []v1alpha1.Family{
+							{
+								Name: "store_label_foo_test",
+								Help: "Foo metric for store-label test",
+								Metrics: []v1alpha1.Metric{
+									{Labels: []v1alpha1.Label{}, Value: "1"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	f := framework.NewInforming(ctx, rmm)
+
+	if err := applyCRDManifests(ctx, t, f); err != nil {
+		t.Fatalf("Failed to apply CRD manifests: %v", err)
+	}
+
+	gvrToKindListMap := make(map[schema.GroupVersionResource]string)
+	for _, crd := range f.GetIndexedCRDs() {
+		for _, version := range crd.Spec.Versions {
+			gv := schema.GroupVersion{Group: crd.Spec.Group, Version: version.Name}
+			f.AddToScheme(func(scheme *runtime.Scheme) {
+				scheme.AddKnownTypes(gv, &unstructured.Unstructured{}, &unstructured.UnstructuredList{})
+			})
+			gvr := schema.GroupVersionResource{
+				Group:    crd.Spec.Group,
+				Version:  version.Name,
+				Resource: crd.Spec.Names.Plural,
+			}
+			gvrToKindListMap[gvr] = crd.Spec.Names.Kind + "List"
+		}
+	}
+	f.WithDynamicClient(gvrToKindListMap)
+
+	if err := applyCRManifests(ctx, t, f); err != nil {
+		t.Fatalf("Failed to apply CR manifests: %v", err)
+	}
+
+	if err := f.Start(ctx, 1); err != nil {
+		t.Fatalf("Failed to start controller: %v", err)
+	}
+
+	time.Sleep(5 * framework.LongTimeInterval)
+
+	metricsOutput, err := f.FetchTelemetryMetrics(ctx)
+	if err != nil {
+		t.Fatalf("Failed to fetch telemetry metrics: %v", err)
+	}
+
+	for _, line := range strings.Split(metricsOutput, "\n") {
+		if strings.HasPrefix(line, "resource_state_metrics_family_cardinality{") {
+			if strings.Contains(line, `store=""`) {
+				t.Errorf("family_cardinality emitted with empty store label (regression): %s", line)
+			}
+		}
+	}
+}
+
 // testStatusUpdate verifies that RMM status is updated with cardinality info.
 func testStatusUpdate(ctx context.Context, t *testing.T, f *framework.Framework) {
 	t.Helper()

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -225,7 +225,7 @@ func (f *Framework) Start(ctx context.Context, workers int) error {
 
 // GetGoldenRuleFiles returns all golden rule file paths for the specified resolver types.
 func GetGoldenRuleFiles(resolverType []v1alpha1.ResolverType) []string {
-	var files []string //nolint:prealloc
+	files := make([]string, 0, len(resolverType))
 
 	for _, resolverType := range resolverType {
 		goldenDir := filepath.Join("golden", string(resolverType))

--- a/tests/golden/unstructured/resourcemetricsmonitor-cardinality-multi-store.yaml
+++ b/tests/golden/unstructured/resourcemetricsmonitor-cardinality-multi-store.yaml
@@ -1,0 +1,81 @@
+---
+# Copyright 2026 The Kubernetes resource-state-metrics Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: resourcemetricsmonitor-cardinality-multi-store
+description: >
+  Test that per-store cardinality is tracked correctly when an RMM spans
+  multiple stores. Before the fix, resource_state_metrics_family_cardinality
+  emitted with store="" (empty label), silently merging all stores into one
+  sample and losing per-store attribution. After the fix each store emits its
+  own labelled sample with the correct count.
+  This file exercises the setup: two stores (Bar and Foo) watched by a single
+  RMM, each contributing independent cardinality that must remain distinct.
+in:
+  apiVersion: resource-state-metrics.instrumentation.k8s-sigs.io/v1alpha1
+  kind: ResourceMetricsMonitor
+  metadata:
+    name: resourcemetricsmonitor-cardinality-multi-store
+    namespace: default
+  spec:
+    configuration:
+      stores:
+        - group: "samplecontroller.k8s.io"
+          version: "v1beta1"
+          kind: "Bar"
+          resource: "bars"
+          resolver: unstructured
+          families:
+            - name: "multi_store_bar_info"
+              help: "Bar resource info for multi-store cardinality test"
+              metrics:
+                - labels: []
+                  value: "1"
+        - group: "samplecontroller.k8s.io"
+          version: "v1alpha1"
+          kind: "Foo"
+          resource: "foos"
+          resolver: unstructured
+          families:
+            - name: "multi_store_foo_info"
+              help: "Foo resource info for multi-store cardinality test"
+              metrics:
+                - labels: []
+                  value: "1"
+metrics:
+  - '# HELP kube_customresource_multi_store_bar_info Bar resource info for multi-store cardinality test'
+  - '# TYPE kube_customresource_multi_store_bar_info gauge'
+  - 'kube_customresource_multi_store_bar_info{group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample",namespace="default"} 1.000000'
+  - 'kube_customresource_multi_store_bar_info{group="samplecontroller.k8s.io",version="v1beta1",kind="Bar",name="test-sample-secondary",namespace="default"} 1.000000'
+  - '# HELP kube_customresource_multi_store_foo_info Foo resource info for multi-store cardinality test'
+  - '# TYPE kube_customresource_multi_store_foo_info gauge'
+  - 'kube_customresource_multi_store_foo_info{group="samplecontroller.k8s.io",version="v1alpha1",kind="Foo",name="test-sample",namespace="default"} 1.000000'
+status:
+  cardinality:
+    total: 3
+    thresholdsExceeded: false
+    perFamily:
+      samplecontroller.k8s.io/v1beta1/Bar:
+        multi_store_bar_info: 2
+      samplecontroller.k8s.io/v1alpha1/Foo:
+        multi_store_foo_info: 1
+  conditions:
+    - type: Processed
+      status: "True"
+      reason: EventHandlerSucceeded
+    - type: CardinalityCutoff
+      status: "False"
+      reason: CardinalityOK
+    - type: CardinalityWarning
+      status: "False"
+      reason: CardinalityOK

--- a/tests/goldenrules_test.go
+++ b/tests/goldenrules_test.go
@@ -315,6 +315,12 @@ func validateStatusOutput(ctx context.Context, t *testing.T, f *framework.Framew
 
 			lastDiff = cmp.Diff(goldenRule.Status, &rmm.Status, opts)
 			if lastDiff == "" {
+				if wantPerFamily := goldenRule.Status.Cardinality.PerFamily; len(wantPerFamily) > 0 {
+					if diff := cmp.Diff(wantPerFamily, rmm.Status.Cardinality.PerFamily); diff != "" {
+						t.Errorf("PerFamily mismatch (-expected +actual):\n%s", diff)
+					}
+				}
+
 				return
 			}
 		}


### PR DESCRIPTION
## Summary
Fixes the store label on the `resource_state_metrics_family_cardinality` and `resource_state_metrics_family_cardinality_limit` telemetry metrics, which was declared but always written as an empty string.

## Describe the changes this patch introduces, in as much detail as possible
I kept the store dimension around end-to-end instead of collapsing it early. added two new maps, `perStoreFamily` and `perStoreFamilyLimit` in aggregation struct. They are populated inside the same loop where storeID is still in scope, and the metric write uses them to fill in the store label properly. The prev `perFamily` and `perFamilyLimit` maps stay untouched because they feed `.status.cardinality.perFamily` on the RMM,which  a user visible API field and I didn't want to change its shape as part of a telemetry-metric fix.

Now prometheus metrics carry a meaningful store label instead of an empty one.
<!-- Does this patch address a corresponding issue? If so please uncomment the line below and specify the issue number. -->

Before:
<img width="1212" height="88" alt="image" src="https://github.com/user-attachments/assets/e03739f5-6ff6-4a27-9e22-b7646b19b3eb" />

After:
<img width="1657" height="388" alt="image" src="https://github.com/user-attachments/assets/088bd0b0-c353-4cd8-89d7-20d5fabf828a" />


<!-- Fixes # -->
Closes : #85 
## Checklist

- [x] `make verify` passes
- [ ] Documentation updated (if applicable)
- [ ] Tests added or updated (if applicable)
