### PR TITLE
fix(internal): resolve cardinality threshold recovery and cutoff enforcement

### DIFF
--- a/internal/cardinality.go
+++ b/internal/cardinality.go
@@ -203,32 +203,49 @@ func (ct *CardinalityTracker) CheckThresholds() []ThresholdViolation {
 		}
 	}
 
-	if ct.storeThreshold > 0 {
-		ratio := float64(ct.storeTotal) / float64(ct.storeThreshold)
-		if ratio > 1.0 {
-			for family := range ct.perFamily {
-				ct.cutoffFamilies[family] = true
-			}
-
-			violations = append(violations, ThresholdViolation{
-				Level:     ThresholdLevelStore,
-				Name:      "store",
-				Current:   ct.storeTotal,
-				Threshold: ct.storeThreshold,
-				Severity:  SeverityCutoff,
-			})
-		} else if ratio >= ct.warningRatio {
-			violations = append(violations, ThresholdViolation{
-				Level:     ThresholdLevelStore,
-				Name:      "store",
-				Current:   ct.storeTotal,
-				Threshold: ct.storeThreshold,
-				Severity:  SeverityWarning,
-			})
-		}
-	}
+	ct.checkStoreThreshold(&violations)
 
 	return violations
+}
+
+func (ct *CardinalityTracker) checkStoreThreshold(violations *[]ThresholdViolation) {
+	if ct.storeThreshold <= 0 {
+		return
+	}
+
+	ratio := float64(ct.storeTotal) / float64(ct.storeThreshold)
+	if ratio > 1.0 {
+		for family := range ct.perFamily {
+			ct.cutoffFamilies[family] = true
+		}
+
+		*violations = append(*violations, ThresholdViolation{
+			Level:     ThresholdLevelStore,
+			Name:      "store",
+			Current:   ct.storeTotal,
+			Threshold: ct.storeThreshold,
+			Severity:  SeverityCutoff,
+		})
+
+		return
+	}
+
+	if ratio >= ct.warningRatio {
+		*violations = append(*violations, ThresholdViolation{
+			Level:     ThresholdLevelStore,
+			Name:      "store",
+			Current:   ct.storeTotal,
+			Threshold: ct.storeThreshold,
+			Severity:  SeverityWarning,
+		})
+	}
+
+	for family, count := range ct.perFamily {
+		threshold, hasThreshold := ct.familyThreshold[family]
+		if !hasThreshold || threshold <= 0 || float64(count)/float64(threshold) <= 1.0 {
+			ct.cutoffFamilies[family] = false
+		}
+	}
 }
 
 // IsFamilyCutoff returns whether a specific family is cut off.

--- a/internal/cardinality_manager.go
+++ b/internal/cardinality_manager.go
@@ -154,34 +154,53 @@ func (m *GlobalCardinalityManager) CheckThresholds(uid types.UID, resourceThresh
 		}
 	}
 
-	// Note: Under this global model, one resource exceeding limits affects all.
-	// More sophisticated strategies (per-namespace isolation, etc.) could be added if needed.
-	if m.globalThreshold > 0 {
-		ratio := float64(m.globalTotal) / float64(m.globalThreshold)
-		if ratio > 1.0 {
-			for r := range m.perResource {
-				m.cutoffResources[r] = true
-			}
-
-			violations = append(violations, ThresholdViolation{
-				Level:     ThresholdLevelGlobal,
-				Name:      "global",
-				Current:   m.globalTotal,
-				Threshold: m.globalThreshold,
-				Severity:  SeverityCutoff,
-			})
-		} else if ratio >= m.warningRatio {
-			violations = append(violations, ThresholdViolation{
-				Level:     ThresholdLevelGlobal,
-				Name:      "global",
-				Current:   m.globalTotal,
-				Threshold: m.globalThreshold,
-				Severity:  SeverityWarning,
-			})
-		}
-	}
+	m.checkGlobalThreshold(resourceThreshold, &violations)
 
 	return violations
+}
+
+func (m *GlobalCardinalityManager) checkGlobalThreshold(resourceThreshold int64, violations *[]ThresholdViolation) {
+	if m.globalThreshold <= 0 {
+		return
+	}
+
+	ratio := float64(m.globalTotal) / float64(m.globalThreshold)
+	if ratio > 1.0 {
+		for r := range m.perResource {
+			m.cutoffResources[r] = true
+		}
+
+		*violations = append(*violations, ThresholdViolation{
+			Level:     ThresholdLevelGlobal,
+			Name:      "global",
+			Current:   m.globalTotal,
+			Threshold: m.globalThreshold,
+			Severity:  SeverityCutoff,
+		})
+
+		return
+	}
+
+	if ratio >= m.warningRatio {
+		*violations = append(*violations, ThresholdViolation{
+			Level:     ThresholdLevelGlobal,
+			Name:      "global",
+			Current:   m.globalTotal,
+			Threshold: m.globalThreshold,
+			Severity:  SeverityWarning,
+		})
+	}
+
+	for r, cardinality := range m.perResource {
+		resThresh := resourceThreshold
+		if resThresh <= 0 {
+			resThresh = m.resourceDefaultThreshold
+		}
+
+		if resThresh <= 0 || float64(cardinality)/float64(resThresh) <= 1.0 {
+			m.cutoffResources[r] = false
+		}
+	}
 }
 
 // IsResourceCutoff returns whether a specific RMM resource is cut off.

--- a/internal/cardinality_test.go
+++ b/internal/cardinality_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 The Kubernetes resource-state-metrics Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+Without WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestCardinalityTracker_StoreThresholdRecovery verifies that when a store's total
+// cardinality exceeds the storeThreshold and then drops back below it (e.g. objects deleted),
+// the cutoff state for store-level families is automatically cleared.
+func TestCardinalityTracker_StoreThresholdRecovery(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewCardinalityTracker(10, 0.8)
+	famName := "test_metric_family"
+
+	// 1. Add objects so store total exceeds threshold (15 > 10)
+	tracker.Update(types.UID("obj-1"), map[string]int64{famName: 8})
+	tracker.Update(types.UID("obj-2"), map[string]int64{famName: 7})
+
+	violations := tracker.CheckThresholds()
+
+	if !tracker.IsFamilyCutoff(famName) {
+		t.Fatalf("expected family %q to be cut off when store total (15) > threshold (10)", famName)
+	}
+
+	hasCutoffViolation := false
+
+	for _, v := range violations {
+		if v.Level == ThresholdLevelStore && v.Severity == SeverityCutoff {
+			hasCutoffViolation = true
+		}
+	}
+
+	if !hasCutoffViolation {
+		t.Errorf("expected store level SeverityCutoff violation, got violations: %+v", violations)
+	}
+
+	// 2. Delete obj-2 so store total drops back to 8 (below threshold 10)
+	tracker.Delete(types.UID("obj-2"))
+
+	violationsAfterDelete := tracker.CheckThresholds()
+
+	if tracker.IsFamilyCutoff(famName) {
+		t.Fatalf("expected family %q cutoff to recover when store total (8) <= threshold (10)", famName)
+	}
+
+	for _, v := range violationsAfterDelete {
+		if v.Severity == SeverityCutoff {
+			t.Errorf("expected no cutoff violations after recovery, got: %+v", v)
+		}
+	}
+}
+
+// TestGlobalCardinalityManager_GlobalThresholdRecovery verifies that when total global
+// cardinality exceeds globalThreshold and then drops back below it, resource cutoffs recover.
+func TestGlobalCardinalityManager_GlobalThresholdRecovery(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewGlobalCardinalityManager(100, 1000, 0.8)
+	uid1 := types.UID("rmm-1")
+	uid2 := types.UID("rmm-2")
+
+	// 1. Exceed global threshold (60 + 50 = 110 > 100)
+	mgr.UpdateResource(uid1, 60)
+	mgr.UpdateResource(uid2, 50)
+
+	mgr.CheckThresholds(uid1, 0)
+	mgr.CheckThresholds(uid2, 0)
+
+	if !mgr.IsResourceCutoff(uid1) || !mgr.IsResourceCutoff(uid2) {
+		t.Fatalf("expected both resources to be cut off when global total (110) > threshold (100)")
+	}
+
+	// 2. Reduce cardinality of rmm-2 so global total drops to 80 (<= 100)
+	mgr.UpdateResource(uid2, 20)
+
+	mgr.CheckThresholds(uid1, 0)
+	mgr.CheckThresholds(uid2, 0)
+
+	if mgr.IsResourceCutoff(uid1) {
+		t.Errorf("expected rmm-1 cutoff to recover when global total (80) <= threshold (100)")
+	}
+
+	if mgr.IsResourceCutoff(uid2) {
+		t.Errorf("expected rmm-2 cutoff to recover when global total (80) <= threshold (100)")
+	}
+}

--- a/internal/events.go
+++ b/internal/events.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubernetes-sigs/resource-state-metrics/internal/version"
 	"github.com/kubernetes-sigs/resource-state-metrics/pkg/apis/resourcestatemetrics/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -387,10 +388,35 @@ func (c *Controller) updateCardinalityStatus(ctx context.Context, resource *v1al
 
 	agg.violations = append(agg.violations, resourceViolations...)
 
+	c.applyGlobalResourceCutoffs()
+
 	c.updateCardinalityMetrics(resource, agg)
 	c.recordCardinalityViolations(resource, agg.violations)
 
 	return c.persistCardinalityStatus(ctx, resource, agg)
+}
+
+// applyGlobalResourceCutoffs syncs resource and global cutoff states across all active stores.
+func (c *Controller) applyGlobalResourceCutoffs() {
+	c.stores.Range(func(key, value any) bool {
+		uid, ok := key.(types.UID)
+		if !ok {
+			return true
+		}
+
+		stores, ok := value.([]*StoreType)
+		if !ok {
+			return true
+		}
+
+		isCutoff := c.globalCardinalityManager.IsResourceCutoff(uid)
+		for _, store := range stores {
+			store.SetResourceCutoff(isCutoff)
+			store.checkAndApplyThresholds()
+		}
+
+		return true
+	})
 }
 
 // recordCardinalityViolations increments the cardinality_exceeded_total metric for violations.

--- a/internal/store.go
+++ b/internal/store.go
@@ -40,6 +40,7 @@ type StoreType struct {
 	celTimeout   time.Duration
 
 	cardinalityTracker *CardinalityTracker
+	resourceCutoff     atomic.Bool
 
 	// synced is set to true after the reflector completes its initial list
 	// via Replace, indicating that all pre-existing objects have been added.
@@ -182,6 +183,16 @@ func (s *StoreType) GetStoreIdentifier() string {
 	return s.Group + "/" + s.Version + "/" + s.Kind
 }
 
+// SetResourceCutoff sets whether this store's parent resource or global controller is cut off.
+func (s *StoreType) SetResourceCutoff(cutoff bool) {
+	s.resourceCutoff.Store(cutoff)
+}
+
+// IsResourceCutoff returns whether this store's parent resource or global controller is cut off.
+func (s *StoreType) IsResourceCutoff() bool {
+	return s.resourceCutoff.Load()
+}
+
 func convertToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
 	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
@@ -234,8 +245,9 @@ func (s *StoreType) checkAndApplyThresholds() []ThresholdViolation {
 
 	violations := s.cardinalityTracker.CheckThresholds()
 
+	resCutoff := s.IsResourceCutoff()
 	for _, family := range s.Families {
-		cutoff := s.cardinalityTracker.IsFamilyCutoff(family.Name)
+		cutoff := resCutoff || s.cardinalityTracker.IsFamilyCutoff(family.Name)
 		family.SetCutoff(cutoff)
 	}
 

--- a/internal/store_test.go
+++ b/internal/store_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Kubernetes resource-state-metrics Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/kubernetes-sigs/resource-state-metrics/pkg/apis/resourcestatemetrics/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+// makeUnstructured is a helper that builds a minimal Unstructured object.
+func makeUnstructured(uid, name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+			"uid":       uid,
+		},
+	}}
+}
+
+// TestStore_ResourceCutoffEnforcement verifies that setting SetResourceCutoff(true)
+// suppresses metric output for all families in the store, and setting SetResourceCutoff(false)
+// restores metric output.
+func TestStore_ResourceCutoffEnforcement(t *testing.T) {
+	t.Parallel()
+
+	fam := &FamilyType{
+		Family: v1alpha1.Family{
+			Name:     "resource_cutoff_family",
+			Help:     "Test metric help",
+			Resolver: v1alpha1.ResolverTypeUnstructured,
+			Metrics: []v1alpha1.Metric{
+				{Value: "1"},
+			},
+		},
+	}
+
+	store := newStore(
+		klog.Background(),
+		[]string{"# HELP resource_cutoff_family\n# TYPE resource_cutoff_family gauge"},
+		[]*FamilyType{fam},
+		v1alpha1.ResolverTypeUnstructured,
+		nil,
+		100000,
+		5,
+	)
+
+	tracker := NewCardinalityTracker(1000, 0.8)
+	store.SetCardinalityTracker(tracker)
+
+	obj := makeUnstructured("uid-resource-cutoff", "pod-cutoff", "default")
+
+	// 1. Initially resourceCutoff is false; Add generates metric output
+	if err := store.Add(obj); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	store.mutex.RLock()
+	metricsBefore := store.metrics[types.UID("uid-resource-cutoff")]
+	store.mutex.RUnlock()
+
+	if len(metricsBefore) == 0 || metricsBefore[0] == "" {
+		t.Fatalf("expected non-empty metric string before cutoff, got %v", metricsBefore)
+	}
+
+	// 2. Set resourceCutoff to true and apply thresholds; metrics generated should be empty string ""
+	store.SetResourceCutoff(true)
+	store.checkAndApplyThresholds()
+
+	if err := store.Add(obj); err != nil {
+		t.Fatalf("Add during cutoff: %v", err)
+	}
+
+	store.mutex.RLock()
+	metricsDuring := store.metrics[types.UID("uid-resource-cutoff")]
+	store.mutex.RUnlock()
+
+	if len(metricsDuring) > 0 && metricsDuring[0] != "" {
+		t.Fatalf("expected empty metric string during resource cutoff, got %v", metricsDuring)
+	}
+
+	// 3. Clear resourceCutoff (false); metric output should resume
+	store.SetResourceCutoff(false)
+	store.checkAndApplyThresholds()
+
+	if err := store.Add(obj); err != nil {
+		t.Fatalf("Add after cutoff recovery: %v", err)
+	}
+
+	store.mutex.RLock()
+	metricsAfter := store.metrics[types.UID("uid-resource-cutoff")]
+	store.mutex.RUnlock()
+
+	if len(metricsAfter) == 0 || metricsAfter[0] == "" {
+		t.Fatalf("expected metric generation to resume after cutoff cleared, got %v", metricsAfter)
+	}
+}


### PR DESCRIPTION
## Summary

This PR resolves three interconnected systemic defects in the cardinality management and enforcement subsystem (Issue #87):

1. **Store-Level Cutoff State Recovery**:
   - Updated `CardinalityTracker.CheckThresholds()` (`internal/cardinality.go`) to explicitly clear `cutoffFamilies[family] = false` when `storeTotal` drops back below `storeThreshold` (and the family's individual threshold, if any, is not exceeded).

2. **Global-Level Cutoff State Recovery**:
   - Updated `GlobalCardinalityManager.CheckThresholds()` (`internal/cardinality_manager.go`) to explicitly clear `cutoffResources[r] = false` when `globalTotal` drops back below `globalThreshold` (and the resource's individual threshold is not exceeded).

3. **Resource & Global Cutoff Enforcement on Metric Generation**:
   - Added `resourceCutoff` tracking to `StoreType` (`internal/store.go`), updated `checkAndApplyThresholds()` to evaluate resource/global cutoffs, and updated `Controller.updateCardinalityStatus()` (`internal/events.go`) to propagate resource cutoffs to all active stores.

Fixes #87

## Checklist

- [x] `make verify` passes
- [x] Documentation updated (if applicable)
- [x] Tests added or updated (if applicable)

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
