### PR TITLE
perf: cache CEL environment to reduce CPU and GC overhead

### DIFF
--- a/pkg/resolver/cel.go
+++ b/pkg/resolver/cel.go
@@ -174,13 +174,13 @@ func (cr *CELResolver) resolveWithTimeout(query string, unstructuredObjectMap ma
 
 var (
 	celEnv     *cel.Env
-	celEnvErr  error
+	errCELEnv  error
 	celEnvOnce sync.Once
 )
 
 func getCELEnv() (*cel.Env, error) {
 	celEnvOnce.Do(func() {
-		celEnv, celEnvErr = cel.NewEnv(
+		celEnv, errCELEnv = cel.NewEnv(
 			cel.CrossTypeNumericComparisons(true),
 			cel.DefaultUTCTimeZone(true),
 			cel.EagerlyValidateDeclarations(true),
@@ -214,7 +214,8 @@ func getCELEnv() (*cel.Env, error) {
 			),
 		)
 	})
-	return celEnv, celEnvErr
+
+	return celEnv, errCELEnv
 }
 
 // unixSecondsBinding implements the logic for the unixSeconds function, which

--- a/pkg/resolver/cel.go
+++ b/pkg/resolver/cel.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/cel-go/cel"
@@ -140,7 +141,7 @@ func (cr *CELResolver) Resolve(query string, unstructuredObjectMap map[string]in
 }
 
 func (cr *CELResolver) resolveWithTimeout(query string, unstructuredObjectMap map[string]interface{}, logger klog.Logger) (map[string]string, error) {
-	env, err := cr.createEnvironment()
+	env, err := getCELEnv()
 	if err != nil {
 		logger.Error(err, "ignoring resolution for query")
 
@@ -171,40 +172,49 @@ func (cr *CELResolver) resolveWithTimeout(query string, unstructuredObjectMap ma
 	return cr.processResult(query, out), nil
 }
 
-func (cr *CELResolver) createEnvironment() (*cel.Env, error) {
-	return cel.NewEnv(
-		cel.CrossTypeNumericComparisons(true),
-		cel.DefaultUTCTimeZone(true),
-		cel.EagerlyValidateDeclarations(true),
-		cel.Function("unixSeconds",
-			cel.Overload("unixSeconds_string",
-				[]*cel.Type{cel.StringType},
-				cel.DoubleType,
-				cel.UnaryBinding(unixSecondsBinding),
+var (
+	celEnv     *cel.Env
+	celEnvErr  error
+	celEnvOnce sync.Once
+)
+
+func getCELEnv() (*cel.Env, error) {
+	celEnvOnce.Do(func() {
+		celEnv, celEnvErr = cel.NewEnv(
+			cel.CrossTypeNumericComparisons(true),
+			cel.DefaultUTCTimeZone(true),
+			cel.EagerlyValidateDeclarations(true),
+			cel.Function("unixSeconds",
+				cel.Overload("unixSeconds_string",
+					[]*cel.Type{cel.StringType},
+					cel.DoubleType,
+					cel.UnaryBinding(unixSecondsBinding),
+				),
 			),
-		),
-		cel.Function("quantity",
-			cel.Overload("quantity_string",
-				[]*cel.Type{cel.StringType},
-				cel.DoubleType,
-				cel.UnaryBinding(quantityBinding),
+			cel.Function("quantity",
+				cel.Overload("quantity_string",
+					[]*cel.Type{cel.StringType},
+					cel.DoubleType,
+					cel.UnaryBinding(quantityBinding),
+				),
 			),
-		),
-		cel.Function("labelPrefix",
-			cel.Overload("labelPrefix_map_string",
-				[]*cel.Type{cel.MapType(cel.StringType, cel.StringType), cel.StringType},
-				cel.MapType(cel.StringType, cel.StringType),
-				cel.BinaryBinding(labelPrefixBinding),
+			cel.Function("labelPrefix",
+				cel.Overload("labelPrefix_map_string",
+					[]*cel.Type{cel.MapType(cel.StringType, cel.StringType), cel.StringType},
+					cel.MapType(cel.StringType, cel.StringType),
+					cel.BinaryBinding(labelPrefixBinding),
+				),
 			),
-		),
-		cel.Function("now",
-			cel.Overload("now_void",
-				[]*cel.Type{},
-				cel.DoubleType,
-				cel.FunctionBinding(nowBinding),
+			cel.Function("now",
+				cel.Overload("now_void",
+					[]*cel.Type{},
+					cel.DoubleType,
+					cel.FunctionBinding(nowBinding),
+				),
 			),
-		),
-	)
+		)
+	})
+	return celEnv, celEnvErr
 }
 
 // unixSecondsBinding implements the logic for the unixSeconds function, which


### PR DESCRIPTION
This PR fixes the performance issue identified in #89 where `cel.NewEnv()` was being called excessively on every `Resolve()` call (amounting to tens of thousands of environment creations per resync).

### Changes
* Cached the `*cel.Env` as a package-level singleton in `pkg/resolver/cel.go` using `sync.Once`. 
* Replaced `cr.createEnvironment()` with `getCELEnv()` in `resolveWithTimeout()`.

Since `cel.Env` and its custom functions are fully stateless and safe for concurrent execution, caching the environment globally eliminates huge amounts of CPU waste and garbage collection pressure without introducing race conditions.

Fixes #89