### PR TITLE
refactor(resolver): define family resolver contract

### DIFF
--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -28,3 +28,8 @@ type Resolver interface {
 	// TODO: All behavioral traits between resolvers must be surfaced here.
 	// underscoreExpansionSupported() bool
 }
+
+// FamilyResolver defines behavior for resolving complete metric families.
+type FamilyResolver interface {
+	Resolve(unstructuredObjectMap map[string]interface{}) ([]ResolvedFamily, error)
+}

--- a/pkg/resolver/starlark.go
+++ b/pkg/resolver/starlark.go
@@ -62,6 +62,8 @@ type StarlarkResolver struct {
 	maxSteps int
 }
 
+var _ FamilyResolver = &StarlarkResolver{}
+
 // NewStarlarkResolver creates a new StarlarkResolver.
 func NewStarlarkResolver(logger klog.Logger, script string, timeout time.Duration, maxSteps int) *StarlarkResolver {
 	if timeout == 0 {


### PR DESCRIPTION
## Summary

Introduces a `FamilyResolver` interface to explicitly define the contract for resolvers that resolve complete metric families.

`StarlarkResolver` already uses a different resolution model from the existing `Resolver` interface:

```go
Resolve(unstructuredObjectMap map[string]interface{}) ([]ResolvedFamily, error)
```

This patch adds a `FamilyResolver` interface matching that existing behavior and adds a compile-time assertion:

```go
var _ FamilyResolver = &StarlarkResolver{}
```

The existing `Resolver` interface remains unchanged and continues to represent expression-level resolution used by the CEL and unstructured resolvers.
This is intentionally a small, behavior-preserving change that makes the existing Starlark resolver capability explicit and provides a foundation for more granular resolver contracts and shared behavioral traits.
No runtime behavior, error handling, timeout behavior, sanitization behavior, or resolver output semantics are changed by this patch.

Part of #15.

## Checklist
* [x] `make verify` passes
* [x] Documentation updated (not applicable; no user-facing behavior change)
* [x] Tests added or updated (not applicable; the new compile-time interface assertion verifies conformance and existing test suites pass)
