### PR TITLE
refactor(resolver): surface composite value capability

### DIFF
--- a/pkg/resolver/capabilities.go
+++ b/pkg/resolver/capabilities.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2026 The Kubernetes resource-state-metrics Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+// ExpressionResolver defines behavior for resolvers that evaluate individual
+// expressions and explicitly surface their behavioral capabilities.
+type ExpressionResolver interface {
+	Resolver
+
+	// SupportsCompositeValues reports whether the resolver can resolve
+	// composite values such as lists and maps.
+	SupportsCompositeValues() bool
+}

--- a/pkg/resolver/capabilities_test.go
+++ b/pkg/resolver/capabilities_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 The Kubernetes resource-state-metrics Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import "testing"
+
+func TestExpressionResolverSupportsCompositeValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		r    ExpressionResolver
+		want bool
+	}{
+		{
+			name: "CEL",
+			r:    &CELResolver{},
+			want: true,
+		},
+		{
+			name: "unstructured",
+			r:    &UnstructuredResolver{},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.r.SupportsCompositeValues(); got != tt.want {
+				t.Errorf("SupportsCompositeValues() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resolver/cel.go
+++ b/pkg/resolver/cel.go
@@ -49,8 +49,8 @@ type CELResolver struct {
 	familyName                 string
 }
 
-// CELResolver implements the Resolver interface.
-var _ Resolver = &CELResolver{}
+// CELResolver implements the ExpressionResolver interface.
+var _ ExpressionResolver = &CELResolver{}
 
 // NewCELResolver returns a new limits-aware CEL resolver.
 func NewCELResolver(logger klog.Logger, costLimit uint64, timeout time.Duration, celEvaluations *prometheus.CounterVec, rmmNamespace, rmmName, familyName string) *CELResolver {
@@ -63,6 +63,11 @@ func NewCELResolver(logger klog.Logger, costLimit uint64, timeout time.Duration,
 		managedRMMName:             rmmName,
 		familyName:                 familyName,
 	}
+}
+
+// SupportsCompositeValues reports whether CELResolver supports composite values.
+func (*CELResolver) SupportsCompositeValues() bool {
+	return true
 }
 
 // costEstimator helps estimate the runtime cost of CEL queries.

--- a/pkg/resolver/unstructured.go
+++ b/pkg/resolver/unstructured.go
@@ -29,12 +29,17 @@ type UnstructuredResolver struct {
 	logger klog.Logger
 }
 
-// UnstructuredResolver implements the Resolver interface.
-var _ Resolver = &UnstructuredResolver{}
+// UnstructuredResolver implements the ExpressionResolver interface.
+var _ ExpressionResolver = &UnstructuredResolver{}
 
 // NewUnstructuredResolver returns a new unstructured resolver.
 func NewUnstructuredResolver(logger klog.Logger) *UnstructuredResolver {
 	return &UnstructuredResolver{logger: logger}
+}
+
+// SupportsCompositeValues reports whether UnstructuredResolver supports composite values.
+func (*UnstructuredResolver) SupportsCompositeValues() bool {
+	return false
 }
 
 // Resolve resolves the given query against the given unstructured object.


### PR DESCRIPTION
## Summary

Introduces an `ExpressionResolver` interface that explicitly surfaces behavioral capabilities for expression-based resolver implementations.

The new interface embeds the existing `Resolver` contract and adds:

```go
SupportsCompositeValues() bool
```

This makes an existing behavioral difference between resolver implementations explicit:
* `CELResolver` reports composite-value support because CEL can resolve composite values such as lists and maps.
* `UnstructuredResolver` reports that composite values are not supported, matching its existing documented behavior.

Both resolver implementations now use compile-time assertions against `ExpressionResolver`.
A table-driven test has also been added to ensure these behavioral capabilities remain explicit and consistent across implementations.
This is a behavior-preserving API refinement intended to incrementally address the shared resolver behavior requirements described in #15.
No resolver output semantics, error handling, timeout behavior, sanitization behavior, or configuration behavior are changed by this patch.

Part of #15.

## Checklist
* [x] `make verify` passes
* [x] Documentation updated (interface and implementation comments updated; no user-facing documentation changes required)
* [x] Tests added or updated
